### PR TITLE
Add scenario for redefining rules

### DIFF
--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1639,7 +1639,7 @@ Feature: TypeQL Define Query
       person owns nickname;
       rule people-bob:
       when {
-        $p isa person, has email "bob@gmail.com";
+        $p has email "bob@gmail.com";
       } then {
         $p has name "Bob";
       };
@@ -2313,4 +2313,3 @@ Feature: TypeQL Define Query
       huge-pineapple sub big-pineapple, relates tree, relates grows-from;
       """
     Then transaction commits
-

--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1617,8 +1617,48 @@ Feature: TypeQL Define Query
       };
       """
 
-
-  Scenario: redefining an existing rule updates its definition
+  Scenario: redefining a rule and querying updates its definition
+    Given typeql define
+      """
+      define
+      nickname sub attribute, value string;
+      person owns nickname;
+      rule people-bob:
+      when {
+        $p isa person;
+      } then {
+        $p has nickname "Bob";
+      };
+      """
+    Then transaction commits
+    When session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      nickname sub attribute, value string;
+      person owns nickname;
+      rule people-bob:
+      when {
+        $p isa person, has email "bob@gmail.com";
+      } then {
+        $p has name "Bob";
+      };
+      """
+    Then transaction commits
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert $x isa person, has email "bob@gmail.com";
+      """
+    Then transaction commits
+    Given session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x has name $a;
+      """
+    Then answer size is: 1
 
 
   #############################


### PR DESCRIPTION
## What is the goal of this PR?

To cover https://github.com/vaticle/typedb/issues/6311 we add a scenario that re-defines a rule and performs a query using inference via the new rule.

## What are the changes implemented in this PR?
* Add a `define` scenario to put another rule with the same name but different content.