### PR TITLE
Ignore two known flakey recursion tests

### DIFF
--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -712,6 +712,7 @@ Feature: Recursion Resolution
     Then materialised and reasoned databases are the same size
 
 
+  @Ignore
   Scenario: ancestor-friend test
 
   from Vieille - Recursive Axioms in Deductive Databases (QSQ approach) p. 186
@@ -1012,6 +1013,7 @@ Feature: Recursion Resolution
     Then materialised and reasoned databases are the same size
 
 
+  @Ignore
   Scenario: given a directed graph, all pairs of vertices (x,y) such that y is reachable from x can be found
 
   test 5.2 from Green - Datalog and Recursive Query Processing


### PR DESCRIPTION
## What is the goal of this PR?

Failure of the test "given a directed graph, all pairs of vertices (x,y) such that y is reachable from x can be found" is caused by lost reiteration flags due to answer deduplication. This will pass when reasoner implements local reiteration.

Failure of the test "ancestor-friend test" has not been investigated, but has been flakey on master for some time.

## What are the changes implemented in this PR?

- Ignore two tests