### PR TITLE
Unignore two recursion tests

### DIFF
--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -712,7 +712,6 @@ Feature: Recursion Resolution
     Then materialised and reasoned databases are the same size
 
 
-  @Ignore
   Scenario: ancestor-friend test
 
   from Vieille - Recursive Axioms in Deductive Databases (QSQ approach) p. 186
@@ -1013,7 +1012,6 @@ Feature: Recursion Resolution
     Then materialised and reasoned databases are the same size
 
 
-  @Ignore
   Scenario: given a directed graph, all pairs of vertices (x,y) such that y is reachable from x can be found
 
   test 5.2 from Green - Datalog and Recursive Query Processing


### PR DESCRIPTION
## What is the goal of this PR?

The following tests in `recursion.feature` have been tested over 10 times each without failure. These have been fixed by ensuring reiteration flags are not missed:
- `given a directed graph, all pairs of vertices (x,y) such that y is reachable from x can be found`
- `ancestor-friend test`

## What are the changes implemented in this PR?

- unignore two tests in `recursion.feature`