### PR TITLE
Pattern variable containing no named variables is invalid

### DIFF
--- a/typeql/language/match.feature
+++ b/typeql/language/match.feature
@@ -2083,6 +2083,17 @@ Feature: TypeQL Match Query
       | x         |
       | key:ref:1 |
 
+
+  Scenario: pattern variable without named variable is invalid
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: read
+    Then typeql match; throws exception
+      """
+      match $x isa person, has name $a; "bob" isa name;
+      """
+
+
   ##################
   # VARIABLE TYPES #
   ##################


### PR DESCRIPTION
## What is the goal of this PR?

We can create implicit variables by omitting named variables in certain parts of a query - however doing so and leaving out ALL named variables in a pattern variable (eg. between semicolons) is meaningless and should throw an error.

## What are the changes implemented in this PR?

* Add a `match` scenario that ensures a match query containing an invalid pattern like `match $x isa person; "bob" isa name;`, where the second half is not connected to anything, is invalid.
