### PR TITLE
Add test for multiple negation blocks

### DIFF
--- a/typeql/language/match.feature
+++ b/typeql/language/match.feature
@@ -2084,6 +2084,18 @@ Feature: TypeQL Match Query
       | key:ref:1 |
 
 
+  Scenario: multiple negations can be applied
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x sub! thing; not { $x type thing; }; not { $x type entity; }; not { $x type relation; };
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:attribute |
+
   Scenario: pattern variable without named variable is invalid
     Given connection close all sessions
     Given connection open data session for database: typedb


### PR DESCRIPTION
## What is the goal of this PR?

We test for multiple negations blocks that involve the same variable.

## What are the changes implemented in this PR?

We add a test for the issue noted in: https://github.com/vaticle/typedb/issues/6471