### PR TITLE
Add scenario for transaction timeouts

### DIFF
--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -595,12 +595,16 @@ Feature: Connection Transaction
   @ignore-typedb
   Scenario: transaction timeouts are configurable
     When connection create database: typedb
-    Then set session option session-idle-timeout-millis to: 120000
+    Then set session option session-idle-timeout-millis to: 20000
     Given connection open schema session for database: typedb
-    # configure transaction timeout to 1 minute
-    Given set transaction option transaction-timeout-millis to: 60000
-    When session opens transaction of type: read
-    Then wait 70 seconds
+    Given set transaction option transaction-timeout-millis to: 10000
+    When session opens transaction of type: write
+    Then wait 8 seconds
+    Then typeql define
+      """
+      define person sub entity;
+      """
+    Then wait 4 seconds
     Then typeql define; throws exception containing "Transaction exceeded maximum configured duration"
       """
       define person sub entity;

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -599,9 +599,12 @@ Feature: Connection Transaction
     Given connection open schema session for database: typedb
     # configure transaction timeout to 1 minute
     Given set transaction option transaction-timeout-millis to: 60000
-    When session opens transaction of type with options: read
+    When session opens transaction of type: read
     Then wait 70 seconds
-    Then typeql define; throw exception containing "transaction timeout"
+    Then typeql define; throws exception containing "Transaction exceeded maximum configured duration"
+      """
+      define person sub entity;
+      """
 
 
 

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -595,13 +595,10 @@ Feature: Connection Transaction
   @ignore-typedb
   Scenario: transaction timeouts are configurable
     When connection create database: typedb
+    Then set session option session-idle-timeout-millis to: 120000
     Given connection open schema session for database: typedb
-    When session opens transaction of type: read
-    # default transaction timeout is 5 minutes
-    Then wait 310 seconds
-    Then typeql define; throw exception containing "transaction timeout"
-    # configure transaction timeout to 1 minutes
-    Given set option transaction-timeout-millis to: 60000
+    # configure transaction timeout to 1 minute
+    Given set transaction option transaction-timeout-millis to: 60000
     When session opens transaction of type with options: read
     Then wait 70 seconds
     Then typeql define; throw exception containing "transaction timeout"

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -590,3 +590,21 @@ Feature: Connection Transaction
     Given connection open schema session for database: typedb
     When session opens transaction of type: read
     Then transaction commits; throws exception
+
+
+  @ignore-typedb
+  Scenario: transaction timeouts are configurable
+    When connection create database: typedb
+    Given connection open schema session for database: typedb
+    When session opens transaction of type: read
+    # default transaction timeout is 5 minutes
+    Then wait 310 seconds
+    Then typeql define; throw exception containing "transaction timeout"
+    # configure transaction timeout to 1 minutes
+    Given set option transaction-timeout-millis to: 60000
+    When session opens transaction of type with options: read
+    Then wait 70 seconds
+    Then typeql define; throw exception containing "transaction timeout"
+
+
+


### PR DESCRIPTION
## What is the goal of this PR?

To test the feature outlined in https://github.com/vaticle/typedb/issues/6487, we add a scenario to test both the default and the configurability of transaction timeouts.

## What are the changes implemented in this PR?

* Add scenario to test transaction timeouts