### PR TITLE
Remove unnecessary TODO in value-predicate.feature

### DIFF
--- a/typeql/reasoner/value-predicate.feature
+++ b/typeql/reasoner/value-predicate.feature
@@ -525,7 +525,6 @@ Feature: Value Predicate Resolution
     Then verify answers are complete
 
 
-  # TODO: move to negation.feature
   Scenario: a negation can filter out variables by equality to another variable with a specified value
     Given reasoning schema
       """


### PR DESCRIPTION
## What is the goal of this PR?

There was a TODO message in value-predicate.feature suggesting to move a particular scenario to negation.feature. However it doesn't make sense to be moved there, because it contains rules. So we deleted the TODO.

## What are the changes implemented in this PR?

Remove unnecessary TODO in value-predicate.feature

fixes #76 