### PR TITLE
Extend setting abstractness scenarios

### DIFF
--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -143,24 +143,16 @@ Feature: Concept Attribute Type
     Then attribute(name) is abstract: true
     When transaction commits
     When session opens transaction of type: write
-    Then attribute(name) as(string) put: alice; throws exception
-    When session opens transaction of type: write
     When put attribute type: email, with value type: string
     Then attribute(email) is abstract: false
     When transaction commits
-    When session opens transaction of type: write
+    When session opens transaction of type: read
     Then attribute(name) is abstract: true
-    Then attribute(name) as(string) put: alice; throws exception
     When session opens transaction of type: write
     Then attribute(email) is abstract: false
     When attribute(email) set abstract: true
     Then attribute(email) is abstract: true
     When transaction commits
-    When session opens transaction of type: write
-    Then attribute(email) as(string) put: alice@email.com; throws exception
-    When session opens transaction of type: write
-    Then attribute(email) is abstract: true
-    Then attribute(email) as(string) put: alice@email.com; throws exception
     When session opens transaction of type: write
     When put attribute type: company-email, with value type: string
     When attribute(company-email) set supertype: email

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -161,6 +161,10 @@ Feature: Concept Attribute Type
     When session opens transaction of type: write
     Then attribute(email) is abstract: true
     Then attribute(email) as(string) put: alice@email.com; throws exception
+    When session opens transaction of type: write
+    When put attribute type: company-email, with value type: string
+    When attribute(company-email) set supertype: email
+    Then attribute(email) set abstract: false; throws exception
 
   Scenario: Attribute types can be subtypes of other attribute types
     When put attribute type: first-name, with value type: string

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -213,6 +213,29 @@ Feature: Concept Relation Type and Role Type
     Then relation(parentship) get role(parent) is abstract: true
     Then relation(parentship) get role(child) is abstract: true
     Then relation(parentship) create new instance; throws exception
+    When session opens transaction of type: write
+    When relation(parentship) set abstract: false
+    When put relation type: fathership
+    When relation(fathership) set supertype: parentship
+    When relation(fathership) set relates role: father as parent
+    When relation(fathership) set relates role: father-child as child
+    When put entity type: person
+    When entity(person) set plays role: fathership:father
+    Then transaction commits
+    When connection close all sessions
+    When connection open data session for database: typedb
+    When session opens transaction of type: write
+    Then $m = relation(fathership) create new instance
+    When $a = entity(person) create new instance
+    When relation $m add player for role(father): $a
+    Then transaction commits
+    When connection close all sessions
+    When connection open schema session for database: typedb
+    When session opens transaction of type: write
+    Then relation(parentship) set abstract: true
+    Then transaction commits
+    When session opens transaction of type: read
+    Then relation(parentship) is abstract: true
 
   Scenario: Relation types must have at least one role in order to commit, unless they are abstract
     When put relation type: connection

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -184,8 +184,6 @@ Feature: Concept Relation Type and Role Type
     Then relation(marriage) get role(wife) is abstract: true
     When transaction commits
     When session opens transaction of type: write
-    Then relation(marriage) create new instance; throws exception
-    When session opens transaction of type: write
     Then relation(parentship) is abstract: false
     Then relation(parentship) get role(parent) is abstract: false
     Then relation(parentship) get role(child) is abstract: false
@@ -196,8 +194,6 @@ Feature: Concept Relation Type and Role Type
     Then relation(marriage) get role(wife) is abstract: true
     When transaction commits
     When session opens transaction of type: write
-    Then relation(marriage) create new instance; throws exception
-    When session opens transaction of type: write
     Then relation(parentship) is abstract: false
     Then relation(parentship) get role(parent) is abstract: false
     Then relation(parentship) get role(child) is abstract: false
@@ -206,15 +202,15 @@ Feature: Concept Relation Type and Role Type
     Then relation(parentship) get role(parent) is abstract: true
     Then relation(parentship) get role(child) is abstract: true
     When transaction commits
-    When session opens transaction of type: write
-    Then relation(parentship) create new instance; throws exception
     When session opens transaction of type: read
     Then relation(parentship) is abstract: true
     Then relation(parentship) get role(parent) is abstract: true
     Then relation(parentship) get role(child) is abstract: true
-    Then relation(parentship) create new instance; throws exception
-    When session opens transaction of type: write
-    When relation(parentship) set abstract: false
+
+  Scenario: relation and role types can be set to abstract when a subtype has instances
+    When put relation type: parentship
+    When relation(parentship) set relates role: parent
+    When relation(parentship) set relates role: child
     When put relation type: fathership
     When relation(fathership) set supertype: parentship
     When relation(fathership) set relates role: father as parent


### PR DESCRIPTION
## What is the goal of this PR?

We add two more cases to the scenarios for testing Type concept abstractness:
1. an abstract attribute with a subtype cannot be made concrete
2. a relation type that has no direct instances, but has a subtype with instances, can be made abstract

## What are the changes implemented in this PR?

* add scenario to test error case for attribute (must only have non-abstract leaves)
* add scenario to test error case for relations (and in general things) where only direct instances matter when setting abstractness, not indirect instances