### PR TITLE
Add scenarios for negation and schema-queries and remove correctness testing for large answer sets

### DIFF
--- a/typeql/language/rule-validation.feature
+++ b/typeql/language/rule-validation.feature
@@ -704,7 +704,7 @@ Feature: TypeQL Rule Validation
       rule add-bob-to-all-employment:
       when {
         $r isa employment;
-        $p isa person, has name bob;
+        $p isa person, has name "bob";
       } then {
         $r (employee: $p) isa employment;
       };

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1162,7 +1162,7 @@ Feature: Negation Resolution
       $x isa soft-drink, has name "Fanta";
       $r "Ocado" isa retailer;
       """
-    Then verify answers are complete
+    Given verifier is initialised
     Given reasoning query
       """
       match

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1139,3 +1139,30 @@ Feature: Negation Resolution
         { $y has index "aa"; } or { $y has index "ee"; } or { $y has index "ff"; } or
         { $y has index "gg"; } or { $y has index "hh"; };
       """
+
+  Scenario: negated and non-negated clauses can use the same rule
+    Given reasoning schema
+      """
+      define
+      rule ocado-sells-all-soft-drinks: when {
+        $y isa soft-drink;
+      } then {
+        $y has retailer 'Ocado';
+      };
+      """
+    Given reasoning data
+      """
+      insert
+      $x isa soft-drink, has name "Fanta";
+      $r "Ocado" isa retailer;
+      """
+    Then verify answers are complete
+    Given reasoning query
+      """
+      match
+        $x has retailer $r;
+        not { $r = "Ocado"; };
+      """
+    Then verify answer size is: 0
+    Then verify answers are sound
+    Then verify answers are complete

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1173,7 +1173,7 @@ Feature: Negation Resolution
     Then verify answers are sound
     Then verify answers are complete
 
-  Scenario: Double negatives are resolved correctly
+  Scenario: double nested negations are resolved correctly
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/relation-inference.feature
+++ b/typeql/reasoner/relation-inference.feature
@@ -221,8 +221,6 @@ Feature: Relation Inference Resolution
       """
       match $r isa friendship;
       """
-    Then verify answers are sound
-    Then verify answers are complete
     # When there is 1 concept we have {aa}.
     # Adding a 2nd concept gives us 2 new relations - where each relation contains b, and one other concept (a or b).
     # Adding a 3rd concept gives us 3 new relations - where each relation contains c, and one other concept (a, b or c).

--- a/typeql/reasoner/schema-queries.feature
+++ b/typeql/reasoner/schema-queries.feature
@@ -440,3 +440,51 @@ Feature: Schema Query Resolution (Variable Types)
     Then verify answer size is: 4
     Then verify answers are sound
     Then verify answers are complete
+
+  Scenario: an inferred relation is correctly matched by a variable type bound to the base relation type
+    Given reasoning schema
+      """
+      define
+      rule strictly-typed-rule:
+      when {
+        $p isa person;
+      } then {
+        (friend: $p) isa friendship;
+      };
+      """
+    Given reasoning data
+      """
+      insert $p isa person;
+      """
+    Given reasoning query
+      """
+      match
+        $p isa person;
+        ($p) isa $f;
+        $f type relation;
+      """
+    Then verify answer size is: 1
+
+  Scenario: an inferred relation is correctly matched with a variable role type bound to the base role type
+    Given reasoning schema
+      """
+      define
+      rule strictly-typed-rule:
+      when {
+        $p isa person;
+      } then {
+        (friend: $p) isa friendship;
+      };
+      """
+    Given reasoning data
+      """
+      insert $p isa person;
+      """
+    Given reasoning query
+      """
+      match
+        $p isa person;
+        ($role: $p) isa friendship;
+        $role type relation:role;
+      """
+    Then verify answer size is: 1

--- a/typeql/reasoner/variable-roles.feature
+++ b/typeql/reasoner/variable-roles.feature
@@ -335,7 +335,6 @@ Feature: Variable Role Resolution
   #  }
 
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
-    Given verifier is initialised
     Given reasoning query
       """
       match
@@ -344,16 +343,12 @@ Feature: Variable Role Resolution
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3) isa binary-base, as role1 and $a1 each have only 1 value
     Then verify answer size is: 63
-    Then verify answers are sound
-    Then verify answers are complete
     Given reasoning query
       """
       match (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
       """
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then verify answer size is: 189
-    Then verify answers are sound
-    Then verify answers are complete
     Given reasoning query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
@@ -373,12 +368,9 @@ Feature: Variable Role Resolution
     # and there are 27 ternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 34 * 27 = 918
     Then verify answer size is: 918
-    Then verify answers are sound
-    Then verify answers are complete
 
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
-    Given verifier is initialised
     Given reasoning query
       """
       match
@@ -387,16 +379,12 @@ Feature: Variable Role Resolution
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary-base
     Then verify answer size is: 918
-    Then verify answers are sound
-    Then verify answers are complete
     Given reasoning query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
       """
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then verify answer size is: 2754
-    Then verify answers are sound
-    Then verify answers are complete
     Given reasoning query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
@@ -413,14 +401,11 @@ Feature: Variable Role Resolution
     # and there are 81 quaternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 81 = 16929
     Then verify answer size is: 16929
-    Then verify answers are sound
-    Then verify answers are complete
 
 
   # Note: This test uses the sub-relation 'quaternary' while the others use the super-relations '{n}-ary-base'.
   # If this test passes while others fail, there may be an inheritance-related issue.
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
-    Given verifier is initialised
     Given reasoning query
       """
       match
@@ -429,16 +414,12 @@ Feature: Variable Role Resolution
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary
     Then verify answer size is: 272
-    Then verify answers are sound
-    Then verify answers are complete
     Given reasoning query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
       """
     # Now the bound role 'role1' is in {a, b}, doubling the answer size
     Then verify answer size is: 544
-    Then verify answers are sound
-    Then verify answers are complete
     Given reasoning query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
@@ -448,5 +429,3 @@ Feature: Variable Role Resolution
     # and there are 16 quaternary relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 16 = 3344
     Then verify answer size is: 3344
-    Then verify answers are sound
-    Then verify answers are complete

--- a/typeql/reasoner/variable-roles.feature
+++ b/typeql/reasoner/variable-roles.feature
@@ -192,7 +192,7 @@ Feature: Variable Role Resolution
     Then verify answers are sound
     Then verify answers are complete
 
-
+  @ignore
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
     Given verifier is initialised
     Given reasoning query

--- a/typeql/reasoner/variable-roles.feature
+++ b/typeql/reasoner/variable-roles.feature
@@ -335,6 +335,7 @@ Feature: Variable Role Resolution
   #  }
 
   Scenario: variable roles are correctly mapped to answers for a ternary relation with 3 possible roleplayers
+    Given verifier is initialised
     Given reasoning query
       """
       match
@@ -377,6 +378,7 @@ Feature: Variable Role Resolution
 
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
+    Given verifier is initialised
     Given reasoning query
       """
       match
@@ -418,6 +420,7 @@ Feature: Variable Role Resolution
   # Note: This test uses the sub-relation 'quaternary' while the others use the super-relations '{n}-ary-base'.
   # If this test passes while others fail, there may be an inheritance-related issue.
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 2 possible roleplayers
+    Given verifier is initialised
     Given reasoning query
       """
       match


### PR DESCRIPTION
## What is the goal of this PR?

We add a number of scenarios that have proven useful in https://github.com/vaticle/typedb/pull/6497. Correctness testing runs for far too long in some variable roles scenarios and so is removed there.

## What are the changes implemented in this PR?

- Add `negation` scenarios
- Add `schema-queries` scenarios
- Fix a small bug in `rule-validation`
- Remove correctness testing when the answer size is large