### PR TITLE
Test non-deterministic results on negated relation which is both inferred and retrieved

### DIFF
--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1204,7 +1204,7 @@ Feature: Negation Resolution
 #    TODO: Add a case with non-zero answers
 
 
-  Scenario: Negated relation which is both retrievable and concludable must always consider both (issue#6500)
+  Scenario: Negated concept considers all rules & retrievables
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1205,7 +1205,6 @@ Feature: Negation Resolution
 
 
   Scenario: Negated relation which is both retrievable and concludable must always consider both (issue#6500)
-    # In the issue, (from: door, to:common-room) was incorrectly returned, as it contradicts a retrievable.
     Given reasoning schema
       """
       define
@@ -1230,12 +1229,11 @@ Feature: Negation Resolution
           (superior: $a, subordinate: $c) isa location-hierarchy;
       };
 
-      rule buggy-reachable-rule:
+      rule reachable-rule:
           when {
               $from isa place;
               $to isa place;
               $common-superior isa place;
-
               (superior: $common-superior, subordinate: $from) isa location-hierarchy;
               (from: $common-superior, to: $to) isa passage;
               not {$common-superior is $to;};
@@ -1252,10 +1250,9 @@ Feature: Negation Resolution
       $common-room isa place, has name "common room";
       $fridge isa place, has name "fridge";
 
-      (superior: $forest,       subordinate: $cabin) isa location-hierarchy;
-      (superior: $cabin,        subordinate: $common-room) isa location-hierarchy;
-      (superior: $common-room,  subordinate: $fridge) isa location-hierarchy;
-
+      (superior: $forest, subordinate: $cabin) isa location-hierarchy;
+      (superior: $cabin, subordinate: $common-room) isa location-hierarchy;
+      (superior: $common-room, subordinate: $fridge) isa location-hierarchy;
       (from: $forest, to: $common-room) isa passage;
       """
     Given verifier is initialised

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1205,6 +1205,7 @@ Feature: Negation Resolution
 
 
   Scenario: Negated concept considers all rules & retrievables
+    Derived from issue #6500
     Given reasoning schema
       """
       define


### PR DESCRIPTION
## What is the goal of this PR?
A rule containing a negated relation was reported to (unsoundly) return 2 or 3 answers non-deterministically. (see [typedb issue#6500](https://github.com/vaticle/typedb/issues/6500)). The relation could be retrieved from the database or inferred using rules. This behaviour isn't shown by release 2.10.0 but can be reproduced on earlier versions.

## What are the changes implemented in this PR?
To prevent regression, the scenario in the issue is converted to a behaviour test and added to the negation test-suite.