### PR TITLE
Reenable reasoner soundness checks fixed by SoundnessVerifier retries

### DIFF
--- a/typeql/reasoner/attribute-attachment.feature
+++ b/typeql/reasoner/attribute-attachment.feature
@@ -74,7 +74,7 @@ Feature: Attribute Attachment Resolution
       match $x isa person, has string-attribute $y;
       """
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
@@ -116,7 +116,7 @@ Feature: Attribute Attachment Resolution
       match $x has string-attribute $y;
       """
     Then verify answer size is: 3
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     Then verify answers are complete
 
 
@@ -226,5 +226,5 @@ Feature: Attribute Attachment Resolution
       match $x has age > 5;
       """
     Then verify answer size is: 1
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     Then verify answers are complete

--- a/typeql/reasoner/concept-inequality.feature
+++ b/typeql/reasoner/concept-inequality.feature
@@ -382,7 +382,7 @@ Feature: Concept Inequality Resolution
     Then verify answers are sound
     Then verify answers are complete
 
-  # TODO enable when we can resolve repeated concludables ( Receives 8 answers instead of 6)
+  # TODO enable when we can resolve repeated concludables ( Receives 2 answers instead of 6)
   @ignore
   # TODO: re-enable once typedb#5821 is fixed (in some answers, $typeof_ax is 'base-attribute' which is incorrect)
   # TODO: re-enable all steps once implicit attribute variables are resolvable

--- a/typeql/reasoner/concept-inequality.feature
+++ b/typeql/reasoner/concept-inequality.feature
@@ -491,4 +491,4 @@ Feature: Concept Inequality Resolution
     # Sprite | Tesco | retailer |
     Then verify answer size is: 1
     Then verify answers are sound
-    # Then verify answers are complete # TODO: Fails
+    # Then verify answers are complete  # TODO: Fails

--- a/typeql/reasoner/concept-inequality.feature
+++ b/typeql/reasoner/concept-inequality.feature
@@ -382,7 +382,7 @@ Feature: Concept Inequality Resolution
     Then verify answers are sound
     Then verify answers are complete
 
-  # TODO enable when we can resolve repeated concludables
+  # TODO enable when we can resolve repeated concludables ( Receives 8 answers instead of 6)
   @ignore
   # TODO: re-enable once typedb#5821 is fixed (in some answers, $typeof_ax is 'base-attribute' which is incorrect)
   # TODO: re-enable all steps once implicit attribute variables are resolvable
@@ -490,5 +490,5 @@ Feature: Concept Inequality Resolution
     # x      | value | type     |
     # Sprite | Tesco | retailer |
     Then verify answer size is: 1
-    # Then verify answers are sound  # TODO: Fails
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are sound
+    # Then verify answers are complete # TODO: Fails

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -1048,12 +1048,11 @@ Feature: Negation Resolution
       """
     Then verify answer size is: 11
     Then verify answers are consistent across 5 executions
-    # TODO: Fails # bug: ConceptMapping
     Then verify answers are sound
     Then verify answers are complete
 
 
-  # TODO: Re-enable once fixed (Completness found missing answer)
+  # TODO: Re-enable once fixed (Completeness found missing answer)
   @ignore
   Scenario: a rule can use negation to exclude things that have any transitive relations to a specific concept
     Given reasoning schema

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -547,7 +547,6 @@ Feature: Negation Resolution
   # MATCHING INFERRED CONCEPTS #
   ##############################
 
-  # TODO: re-enable all steps when 3-hop transitivity is resolvable
   Scenario: negation of a transitive relation is resolvable
     Given reasoning schema
       """
@@ -1049,11 +1048,12 @@ Feature: Negation Resolution
       """
     Then verify answer size is: 11
     Then verify answers are consistent across 5 executions
-    # Then verify answers are sound  # TODO: Fails
+    # TODO: Fails # bug: ConceptMapping
+    Then verify answers are sound
     Then verify answers are complete
 
 
-  # TODO: Re-enable once fixed
+  # TODO: Re-enable once fixed (Completness found missing answer)
   @ignore
   Scenario: a rule can use negation to exclude things that have any transitive relations to a specific concept
     Given reasoning schema

--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -1031,7 +1031,6 @@ Feature: Recursion Resolution
       get $y;
       """
     Then verify answer size is: 4
-
     Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails due to put race condition
     Then verify answer set is equivalent for query

--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -240,7 +240,6 @@ Feature: Recursion Resolution
       """
     # Relation-3-to-2 should not make any additional inferences - it should merely assert that the relations exist
     Then verify answer size is: 2
-    # TODO: Fails # bug: ConceptMapping
     Then verify answers are sound
     Then verify answers are complete
 
@@ -1033,7 +1032,6 @@ Feature: Recursion Resolution
       """
     Then verify answer size is: 4
 
-    # TODO: Fails # bug: ConceptMapping
     Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails due to put race condition
     Then verify answer set is equivalent for query

--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -232,7 +232,7 @@ Feature: Recursion Resolution
       """
     # Each of the two material relation1 instances should infer a single relation3 via 1-to-2 and 2-to-3
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
@@ -240,7 +240,8 @@ Feature: Recursion Resolution
       """
     # Relation-3-to-2 should not make any additional inferences - it should merely assert that the relations exist
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    # TODO: Fails # bug: ConceptMapping
+    Then verify answers are sound
     Then verify answers are complete
 
 
@@ -973,7 +974,6 @@ Feature: Recursion Resolution
       get $x, $y;
       """
 
-
   Scenario: given an undirected graph, all vertices connected to a given vertex can be found
 
   For this test, the graph looks like the following:
@@ -1032,7 +1032,9 @@ Feature: Recursion Resolution
       get $y;
       """
     Then verify answer size is: 4
-    # Then verify answers are sound  # TODO: Fails
+
+    # TODO: Fails # bug: ConceptMapping
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails due to put race condition
     Then verify answer set is equivalent for query
       """

--- a/typeql/reasoner/relation-inference.feature
+++ b/typeql/reasoner/relation-inference.feature
@@ -683,7 +683,6 @@ Feature: Relation Inference Resolution
       """
     # (a,a), (b,b), (c,c)
     Then verify answer size is: 3
-    # TODO: Fails # bug: ConceptMapping
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -696,7 +695,6 @@ Feature: Relation Inference Resolution
       get $x, $y;
       """
     Then verify answer size is: 1
-    # TODO: Fails # bug: ConceptMapping
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query

--- a/typeql/reasoner/relation-inference.feature
+++ b/typeql/reasoner/relation-inference.feature
@@ -347,7 +347,6 @@ Feature: Relation Inference Resolution
   # SYMMETRY #
   ############
 
-  # TODO: re-enable all steps when resolvable (currently takes too long)
   Scenario: when a relation is symmetric, its symmetry can be used to make additional inferences
     Given reasoning schema
       """
@@ -459,7 +458,6 @@ Feature: Relation Inference Resolution
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps when 3-hop transitivity is resolvable
   Scenario: when a query using transitivity has a limit exceeding the result size, answers are consistent between runs
     Given reasoning schema
       """
@@ -685,7 +683,8 @@ Feature: Relation Inference Resolution
       """
     # (a,a), (b,b), (c,c)
     Then verify answer size is: 3
-    # Then verify answers are sound  # TODO: Fails
+    # TODO: Fails # bug: ConceptMapping
+    Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
@@ -697,7 +696,8 @@ Feature: Relation Inference Resolution
       get $x, $y;
       """
     Then verify answer size is: 1
-    # Then verify answers are sound  # TODO: Fails
+    # TODO: Fails # bug: ConceptMapping
+    Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
       """
@@ -712,7 +712,6 @@ Feature: Relation Inference Resolution
   # UNTYPED MATCH QUERY #
   #######################
 
-  # TODO: re-enable all steps when fixed (#75)
   Scenario: the relation type constraint can be excluded from a reasoned match query
     Given reasoning schema
       """
@@ -749,7 +748,6 @@ Feature: Relation Inference Resolution
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps when fixed (#75)
   Scenario: when the relation type is excluded in a reasoned match query, all valid roleplayer combinations are matches
     Given reasoning schema
       """
@@ -796,7 +794,6 @@ Feature: Relation Inference Resolution
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps when fixed (#75)
   Scenario: when the relation type is excluded in a reasoned match query, all types of relations match
     Given reasoning schema
       """
@@ -844,8 +841,6 @@ Feature: Relation Inference Resolution
       match ($a, $b);
       """
 
-
-  # TODO: re-enable all steps when fixed (#75)
   Scenario: conjunctions of untyped reasoned relations are correctly resolved
     Given reasoning schema
       """

--- a/typeql/reasoner/schema-queries.feature
+++ b/typeql/reasoner/schema-queries.feature
@@ -52,7 +52,6 @@ Feature: Schema Query Resolution (Variable Types)
       """
     # each scenario specialises the schema further
 
-  # TODO: re-enable all steps once schema queries are resolvable (#75)
   Scenario: all instances and their types can be retrieved
     Given reasoning schema
       """
@@ -206,7 +205,6 @@ Feature: Schema Query Resolution (Variable Types)
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps once schema queries are resolvable (#75)
   Scenario: all inferred instances of types that are subtypes of a given type can be retrieved
     Given reasoning schema
       """
@@ -250,7 +248,6 @@ Feature: Schema Query Resolution (Variable Types)
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps once schema queries are resolvable (#75)
   Scenario: all inferred instances of types that can play a given role can be retrieved
     Given reasoning schema
       """

--- a/typeql/reasoner/schema-queries.feature
+++ b/typeql/reasoner/schema-queries.feature
@@ -108,7 +108,6 @@ Feature: Schema Query Resolution (Variable Types)
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps once schema queries are resolvable (#75)
   Scenario: all relations and their types can be retrieved
     Given reasoning schema
       """
@@ -145,7 +144,6 @@ Feature: Schema Query Resolution (Variable Types)
     Then verify answers are complete
 
 
-  # TODO: re-enable all steps once schema queries are resolvable (#75)
   Scenario: all inferred instances of types that can own a given attribute type can be retrieved
     Given reasoning schema
       """
@@ -319,7 +317,6 @@ Feature: Schema Query Resolution (Variable Types)
   Scenario: all inferred instances of relation types that relate a given role can be retrieved
 
 
-  # TODO: re-enable all steps once schema queries are resolvable (#75)
   Scenario: all roleplayers and their types can be retrieved from a relation
     Given reasoning schema
       """

--- a/typeql/reasoner/value-predicate.feature
+++ b/typeql/reasoner/value-predicate.feature
@@ -102,7 +102,6 @@ Feature: Value Predicate Resolution
       """
     Then verify answer size is: <answer-size>
     Then verify answers are sound
-
     Then verify answers are complete
 
     Examples:

--- a/typeql/reasoner/value-predicate.feature
+++ b/typeql/reasoner/value-predicate.feature
@@ -101,7 +101,8 @@ Feature: Value Predicate Resolution
         $n <op> 1667;
       """
     Then verify answer size is: <answer-size>
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
+
     Then verify answers are complete
 
     Examples:
@@ -138,8 +139,9 @@ Feature: Value Predicate Resolution
         $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
       """
+     # TODO: Answer size?
     Then verify answer size is: <answer-size>
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
 
     Examples:
@@ -178,8 +180,10 @@ Feature: Value Predicate Resolution
         $m <op> $n;
         $n <op> 1667;
       """
+
+    # TODO: Answer size?
     Then verify answer size is: <answer-size>
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
 
     Examples:
@@ -229,7 +233,7 @@ Feature: Value Predicate Resolution
     # Fanta | Tesco |
     # Tango | Tesco |
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
 
 
@@ -270,7 +274,7 @@ Feature: Value Predicate Resolution
     # Fanta | Ocado |
     # Tango | Ocado |
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
 
 
@@ -310,7 +314,7 @@ Feature: Value Predicate Resolution
         $rx contains "land";
       """
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     Then verify answers are complete
 
 
@@ -362,7 +366,7 @@ Feature: Value Predicate Resolution
     # Tango | Iceland   | Tango | Iceland   |
     # Tango | Poundland | Tango | Poundland |
     Then verify answer size is: 8
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
 
 
@@ -423,7 +427,7 @@ Feature: Value Predicate Resolution
     # Fanta | Londis    | Fanta | Iceland   |
     # Tango | Londis    | Tango | Iceland   |
     Then verify answer size is: 16
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
 
 
@@ -463,7 +467,7 @@ Feature: Value Predicate Resolution
     # Fanta | Tesco |
     # Tango | Tesco |
     Then verify answer size is: 2
-    # Then verify answers are sound  # TODO: Fails
+    Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """

--- a/typeql/reasoner/value-predicate.feature
+++ b/typeql/reasoner/value-predicate.feature
@@ -139,7 +139,6 @@ Feature: Value Predicate Resolution
         $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
       """
-     # TODO: Answer size?
     Then verify answer size is: <answer-size>
     Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails
@@ -180,8 +179,6 @@ Feature: Value Predicate Resolution
         $m <op> $n;
         $n <op> 1667;
       """
-
-    # TODO: Answer size?
     Then verify answer size is: <answer-size>
     Then verify answers are sound
     # Then verify answers are complete  # TODO: Fails

--- a/typeql/reasoner/variable-roles.feature
+++ b/typeql/reasoner/variable-roles.feature
@@ -170,7 +170,6 @@ Feature: Variable Role Resolution
       get $a, $b, $r2;
       """
     Then verify answer size is: 18
-    # TODO: Fails non-deterministically with ArrayIndexOutOfBoundsException
     Then verify answers are sound
     Then verify answers are complete
 
@@ -193,7 +192,6 @@ Feature: Variable Role Resolution
     Then verify answers are sound
     Then verify answers are complete
 
-  # TODO: Fails non-deterministically with ArrayIndexOutOfBoundsException
   @ignore
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
     Given verifier is initialised
@@ -217,7 +215,6 @@ Feature: Variable Role Resolution
     Then verify answers are complete
 
 
-  # TODO: Fails non-deterministically with ArrayIndexOutOfBoundsException
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
     Given verifier is initialised
     Given reasoning query

--- a/typeql/reasoner/variable-roles.feature
+++ b/typeql/reasoner/variable-roles.feature
@@ -170,6 +170,7 @@ Feature: Variable Role Resolution
       get $a, $b, $r2;
       """
     Then verify answer size is: 18
+    # TODO: Fails non-deterministically with ArrayIndexOutOfBoundsException
     Then verify answers are sound
     Then verify answers are complete
 
@@ -192,6 +193,7 @@ Feature: Variable Role Resolution
     Then verify answers are sound
     Then verify answers are complete
 
+  # TODO: Fails non-deterministically with ArrayIndexOutOfBoundsException
   @ignore
   Scenario: converting a fixed role to a variable bound with 'type role' (?)
     Given verifier is initialised
@@ -215,6 +217,7 @@ Feature: Variable Role Resolution
     Then verify answers are complete
 
 
+  # TODO: Fails non-deterministically with ArrayIndexOutOfBoundsException
   Scenario: converting a fixed role to a variable bound with 'sub role' (?)
     Given verifier is initialised
     Given reasoning query


### PR DESCRIPTION
## What is the goal of this PR?
Some scenarios had soundness checks commented out, since SoundnessVerifier was throwing an error (even though the answers may have been sound). 

These checks fail non-deterministically when tested by SoundnessVerifier without the retries. 

## What are the changes implemented in this PR?
This PR uncomments the soundness checks. 
It also removes old TODO's from the reasoner BDDs
 