### PR TITLE
Re-enable supported reasoner completeness checks

### DIFF
--- a/typeql/reasoner/concept-inequality.feature
+++ b/typeql/reasoner/concept-inequality.feature
@@ -491,4 +491,4 @@ Feature: Concept Inequality Resolution
     # Sprite | Tesco | retailer |
     Then verify answer size is: 1
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -974,7 +974,7 @@ Feature: Negation Resolution
     Then verify answer size is: 0
     Then verify answers are consistent across 5 executions
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
 
   Scenario: when evaluating negation blocks, completion of incomplete queries is not acknowledged
@@ -1130,7 +1130,6 @@ Feature: Negation Resolution
     Then verify answer size is: 5
     Then verify answers are sound
     Then verify answers are complete
-    # TODO: Check again if we correctly mean '$y isa node' when we enable this test
     Then verify answer set is equivalent for query
       """
       match

--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -1032,7 +1032,7 @@ Feature: Recursion Resolution
       """
     Then verify answer size is: 4
     # Then verify answers are sound     # TODO: Runs out of memory on grabl
-    # Then verify answers are complete  # TODO: Fails due to put race condition
+    Then verify answers are complete
     Then verify answer set is equivalent for query
       """
       match

--- a/typeql/reasoner/value-predicate.feature
+++ b/typeql/reasoner/value-predicate.feature
@@ -140,7 +140,7 @@ Feature: Value Predicate Resolution
       """
     Then verify answer size is: <answer-size>
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
     Examples:
       | op | answer-size |
@@ -180,7 +180,7 @@ Feature: Value Predicate Resolution
       """
     Then verify answer size is: <answer-size>
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
     Examples:
       | op | answer-size |
@@ -230,7 +230,7 @@ Feature: Value Predicate Resolution
     # Tango | Tesco |
     Then verify answer size is: 2
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
 
   Scenario: inferred attributes can be matched by equality to a variable that is not equal to a specified value
@@ -271,7 +271,7 @@ Feature: Value Predicate Resolution
     # Tango | Ocado |
     Then verify answer size is: 2
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -363,7 +363,7 @@ Feature: Value Predicate Resolution
     # Tango | Poundland | Tango | Poundland |
     Then verify answer size is: 8
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
 
   # TODO: re-enable all steps when fixed (#75)
@@ -424,7 +424,7 @@ Feature: Value Predicate Resolution
     # Tango | Londis    | Tango | Iceland   |
     Then verify answer size is: 16
     Then verify answers are sound
-    # Then verify answers are complete  # TODO: Fails
+    Then verify answers are complete
 
 
   Scenario: in a rule, 'not { $x = $y; }' is the same as saying '$x != $y'


### PR DESCRIPTION
## What is the goal of this PR?
This PR reenables completeness checks which were disabled due to failures. Some (if not all) of these were failing due to the forward-chaining oracle not evaluating rules according to the stratification (induced by negation). This will be fixed with [PR#6606](https://github.com/vaticle/typedb/pull/6606).
Some tests are just not supported by the current oracle and remain disabled.

## What are the changes implemented in this PR?
Uncomments various reasoner completeness checks.