### PR TITLE
Multi-variable sorting and incomparable sorting scenarios

### DIFF
--- a/typeql/language/get.feature
+++ b/typeql/language/get.feature
@@ -89,7 +89,6 @@ Feature: TypeQL Get Clause
       """
 
 
-
   ########
   # SORT #
   ########
@@ -138,29 +137,6 @@ Feature: TypeQL Get Clause
       | correlation   | double   | -29.7      | -0.9             | 0.01             | 100.0      |
       | date-of-birth | datetime | 1970-01-01 | 1999-12-31T23:00 | 1999-12-31T23:01 | 2020-02-29 |
 
-  Scenario:
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y;
-      """
-    Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | value:name:Brenda    |
-      | key:ref:2 | value:name:Frederick |
-      | key:ref:0 | value:name:Gary      |
-      | key:ref:1 | value:name:Jemima    |
 
   Scenario: sort order can be ascending or descending
     Given typeql insert


### PR DESCRIPTION
## What is the goal of this PR?

Because TypeQL & TypeDB support multi-variable sorting with different orders for each variable (https://github.com/vaticle/typeql/pull/230 and https://github.com/vaticle/typedb/pull/6641), we update the scenarios for this case. We also add a validation scenario that check the rejection of queries that sort on attributes that may not be sortable.

## What are the changes implemented in this PR?

* Update existing multi-variable sorting scenario to use different dirctions for each variable
* Add scenario that validates the exceptional case of sorting incomparable attributes