### PR TITLE
Migrate to Factory

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -25,12 +25,12 @@ build:
       owner: vaticle
       branch: master
     dependency-analysis:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
-      image: vaticle-ubuntu-21.04
+      image: vaticle-ubuntu-22.04
       command: |
         bazel build //... --test_output=errors
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage

--- a/BUILD
+++ b/BUILD
@@ -22,7 +22,7 @@ checkstyle_test(
     include = glob([
         ".bazelrc",
         ".gitignore",
-        ".grabl/*",
+        ".factory/*",
         "BUILD",
         "WORKSPACE",
     ]),

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -21,5 +21,5 @@ def vaticle_dependencies():
     git_repository(
         name = "vaticle_dependencies",
         remote = "https://github.com/vaticle/dependencies",
-        commit = "a8b3b714a5e0562d41f4c05ca8f266d48b7d0fd3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
+        commit = "4464b506ca469f37d3b696fb2f1eda34061cdaa1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_dependencies
     )

--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -1031,7 +1031,7 @@ Feature: Recursion Resolution
       get $y;
       """
     Then verify answer size is: 4
-    # Then verify answers are sound     # TODO: Runs out of memory on grabl
+    # Then verify answers are sound     # TODO: Runs out of memory on factory
     Then verify answers are complete
     Then verify answer set is equivalent for query
       """


### PR DESCRIPTION
## What is the goal of this PR?

We've migrated our continuous integration for this repo to Vaticle Factory from Grabl.

## What are the changes implemented in this PR?

We've updated:
- dependencies.
- uses of pyenv that are no longer in line with our approach.
- machine definitions from ubuntu 21.04 to 22.04.
- references to Grabl to Factory.
