### PR TITLE
Update tests for disjunctions in rules

### DIFF
--- a/typeql/language/rule-validation.feature
+++ b/typeql/language/rule-validation.feature
@@ -283,36 +283,19 @@ Feature: TypeQL Rule Validation
       """
 
 
-  Scenario: the variables in the conclusion of a rule must be bound in all branches in its 'when' clause
+  Scenario: the variables in the conclusion of a rule must be bound in the trunk of its 'when' clause
     Then typeql define; throws exception
       """
       define
       person plays both-named-robert:named-robert;
       both-named-robert sub relation, relates named-robert;
-      rule typo-in-two-roberts-are-both-named-robert: when {
-        $p isa person, has name "Robert";
-        {$p1 isa person, has name "Robert";} or {$p2 isa person, has name "Bob";};
-      } then {
-        (named-robert: $p, named-robert: $p2) isa both-named-robert;
-      };
-      """
-
-
-  Scenario: variables in a rule's 'then' need not be in the trunk of the 'when' as long as they appear in all branches
-    Then typeql define
-      """
-      define
-      person plays both-named-robert:named-robert;
-      both-named-robert sub relation, relates named-robert;
-      rule two-roberts-are-both-named-robert: when {
-        {$p1 isa person, has name "Robert";} or {$p1 isa person, has name "Bob";};
+      rule two-roberts-are-both-named-robert-with-branches: when {
+        $p1 isa person, has name "Robert";
         {$p2 isa person, has name "Robert";} or {$p2 isa person, has name "Bob";};
       } then {
         (named-robert: $p1, named-robert: $p2) isa both-named-robert;
       };
       """
-    Then transaction commits
-
 
   Scenario: when a rule has an undefined attribute set in its 'then' clause, an error is thrown
     Given typeql define; throws exception

--- a/typeql/language/rule-validation.feature
+++ b/typeql/language/rule-validation.feature
@@ -257,6 +257,20 @@ Feature: TypeQL Rule Validation
     Then transaction commits
 
 
+  Scenario: a rule can use a negated disjunction in its 'when' clause
+    Then typeql define
+      """
+      define
+      rule those-who-arent-sophie-and-fiona-have-nickname-notfi: when {
+        $p isa person;
+        not { {$p has name "Sophie";} or {$p has name "Fiona";}; };
+      } then {
+        $p has nickname "NotFi";
+      };
+      """
+    Then transaction commits
+
+
   Scenario: when a rule contains an unbound variable in the 'then' clause, an error is thrown
     Then typeql define; throws exception
       """

--- a/typeql/reasoner/attribute-attachment.feature
+++ b/typeql/reasoner/attribute-attachment.feature
@@ -198,6 +198,43 @@ Feature: Attribute Attachment Resolution
     Then verify answers are complete
 
 
+  Scenario: a rule with disjunctions considers every branch
+    Given reasoning schema
+      """
+      define
+      crisps sub entity, owns retailer;
+      rule tesco-sells-everything-ocado-sells-and-all-soft-drinks: when {
+        {$x has retailer 'Ocado';} or {$x isa soft-drink;};
+      } then {
+        $x has retailer 'Tesco';
+      };
+      """
+    Given reasoning data
+      """
+      insert
+      $aeW isa crisps;
+      $aeX isa crisps, has retailer 'Ocado';
+      $aeY isa soft-drink;
+      $aeZ isa soft-drink;
+      """
+    Given verifier is initialised
+    Given reasoning query
+      """
+      match $x has retailer 'Tesco';
+      """
+    Then verify answer size is: 3
+    Then verify answers are sound
+    Then verify answers are complete
+    Then verify answer set is equivalent for query
+      """
+      match
+      $x isa $t;
+      {$x has retailer 'Ocado';} or {$t type soft-drink;};
+      get $x;
+      """
+
+
+
   Scenario: Querying for anonymous attributes with predicates finds the correct answers
     Given reasoning schema
       """
@@ -226,5 +263,12 @@ Feature: Attribute Attachment Resolution
       match $x has age > 5;
       """
     Then verify answer size is: 1
+    Then verify answers are sound
+    Then verify answers are complete
+    Given reasoning query
+      """
+      match $x has age > 5; $x has age < 8;
+      """
+    Then verify answer size is: 0
     Then verify answers are sound
     Then verify answers are complete

--- a/typeql/reasoner/attribute-attachment.feature
+++ b/typeql/reasoner/attribute-attachment.feature
@@ -204,7 +204,8 @@ Feature: Attribute Attachment Resolution
       define
       crisps sub entity, owns retailer;
       rule tesco-sells-everything-ocado-sells-and-all-soft-drinks: when {
-        {$x has retailer 'Ocado';} or {$x isa soft-drink;};
+        $x isa $t;
+        {$x has retailer 'Ocado';} or {$t type soft-drink;};
       } then {
         $x has retailer 'Tesco';
       };
@@ -240,7 +241,8 @@ Feature: Attribute Attachment Resolution
       define
       crisps sub entity, owns retailer;
       rule tesco-sells-everything-that-Ocado-doesnt-except-soft-drinks: when {
-        not { {$x has retailer 'Ocado';} or {$x isa soft-drink;}; };
+        $x isa $t;
+        not { {$x has retailer 'Ocado';} or {$t type soft-drink;}; };
       } then {
         $x has retailer 'Tesco';
       };

--- a/typeql/reasoner/attribute-attachment.feature
+++ b/typeql/reasoner/attribute-attachment.feature
@@ -234,7 +234,6 @@ Feature: Attribute Attachment Resolution
       """
 
 
-
   Scenario: Querying for anonymous attributes with predicates finds the correct answers
     Given reasoning schema
       """

--- a/typeql/reasoner/attribute-attachment.feature
+++ b/typeql/reasoner/attribute-attachment.feature
@@ -234,6 +234,42 @@ Feature: Attribute Attachment Resolution
       """
 
 
+  Scenario: a rule with negated disjunctions considers every branch
+    Given reasoning schema
+      """
+      define
+      crisps sub entity, owns retailer;
+      rule tesco-sells-everything-that-Ocado-doesnt-except-soft-drinks: when {
+        not { {$x has retailer 'Ocado';} or {$x isa soft-drink;}; };
+      } then {
+        $x has retailer 'Tesco';
+      };
+      """
+    Given reasoning data
+      """
+      insert
+      $aeW isa crisps;
+      $aeX isa crisps, has retailer 'Ocado';
+      $aeY isa soft-drink;
+      $aeZ isa soft-drink;
+      """
+    Given verifier is initialised
+    Given reasoning query
+      """
+      match $x has retailer 'Tesco';
+      """
+    Then verify answer size is: 1
+    Then verify answers are sound
+    Then verify answers are complete
+    Then verify answer set is equivalent for query
+      """
+      match
+      $x isa $t;
+      not {$x has retailer 'Ocado';}; not {$t type soft-drink;};
+      get $x;
+      """
+
+
   Scenario: Querying for anonymous attributes with predicates finds the correct answers
     Given reasoning schema
       """


### PR DESCRIPTION
## What is the goal of this PR?
Update behaviour tests to reflect support for disjunctions in rules. 

## What are the changes implemented in this PR?
* Update rule-validation to 
1. Allow disjunctions in rules
2. Test that all variables in the 'then' of a rule occur in the trunk (outside negations or nested disjunctions) of the 'when'
3. Ensure negative cycle detection considers all branches of a disjunction

* Add a reasoner test  to ensure TypeDB handles disjunctions in rules properly.