### PR TITLE
Introduce scenarios for attribute ownership uniqueness

### DIFF
--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -30,7 +30,7 @@ Feature: Concept Entity
     Given put attribute type: username, with value type: string
     Given put attribute type: email, with value type: string
     Given put entity type: person
-    Given entity(person) set owns key type: username
+    Given entity(person) set owns attribute type: username, with annotations: key
     Given entity(person) set owns attribute type: email
     Given transaction commits
     Given connection close all sessions

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -33,10 +33,10 @@ Feature: Concept Relation
     Given put relation type: marriage
     Given relation(marriage) set relates role: wife
     Given relation(marriage) set relates role: husband
-    Given relation(marriage) set owns key type: license
+    Given relation(marriage) set owns attribute type: license, with annotations: key
     Given relation(marriage) set owns attribute type: date
     Given put entity type: person
-    Given entity(person) set owns key type: username
+    Given entity(person) set owns attribute type: username, with annotations: key
     Given entity(person) set plays role: marriage:wife
     Given entity(person) set plays role: marriage:husband
     Given transaction commits

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -486,27 +486,27 @@ Feature: Concept Attribute Type
   Scenario: Attribute types can have keys
     When put attribute type: country-code, with value type: string
     When put attribute type: country-name, with value type: string
-    When attribute(country-name) set owns key type: country-code
-    Then attribute(country-name) get owns key types contain:
+    When attribute(country-name) set owns attribute type: country-code, with annotations: key
+    Then attribute(country-name) get owns types with annotations: key; contain:
       | country-code |
     When transaction commits
     When session opens transaction of type: read
-    Then attribute(country-name) get owns key types contain:
+    Then attribute(country-name) get owns types with annotations: key; contain:
       | country-code |
 
   Scenario: Attribute types can unset keys
     When put attribute type: country-code-1, with value type: string
     When put attribute type: country-code-2, with value type: string
     When put attribute type: country-name, with value type: string
-    When attribute(country-name) set owns key type: country-code-1
-    When attribute(country-name) set owns key type: country-code-2
-    When attribute(country-name) unset owns key type: country-code-1
-    Then attribute(country-name) get owns key types do not contain:
+    When attribute(country-name) set owns attribute type: country-code-1, with annotations: key
+    When attribute(country-name) set owns attribute type: country-code-2, with annotations: key
+    When attribute(country-name) unset owns attribute type: country-code-1
+    Then attribute(country-name) get owns types with annotations: key; do not contain:
       | country-code-1 |
     When transaction commits
     When session opens transaction of type: write
-    When attribute(country-name) unset owns key type: country-code-2
-    Then attribute(country-name) get owns key types do not contain:
+    When attribute(country-name) unset owns attribute type: country-code-2
+    Then attribute(country-name) get owns types with annotations: key; do not contain:
       | country-code-1 |
       | country-code-2 |
 
@@ -545,16 +545,16 @@ Feature: Concept Attribute Type
     When put attribute type: country-code, with value type: string
     When put attribute type: country-abbreviation, with value type: string
     When put attribute type: country-name, with value type: string
-    When attribute(country-name) set owns key type: country-code
+    When attribute(country-name) set owns attribute type: country-code, with annotations: key
     When attribute(country-name) set owns attribute type: country-abbreviation
-    Then attribute(country-name) get owns key types contain:
+    Then attribute(country-name) get owns types with annotations: key; contain:
       | country-code |
     Then attribute(country-name) get owns attribute types contain:
       | country-code         |
       | country-abbreviation |
     When transaction commits
     When session opens transaction of type: read
-    Then attribute(country-name) get owns key types contain:
+    Then attribute(country-name) get owns types with annotations: key; contain:
       | country-code |
     Then attribute(country-name) get owns attribute types contain:
       | country-code         |
@@ -565,19 +565,19 @@ Feature: Concept Attribute Type
     When put attribute type: abbreviation, with value type: string
     When put attribute type: name, with value type: string
     When attribute(name) set abstract: true
-    When attribute(name) set owns key type: hash
+    When attribute(name) set owns attribute type: hash, with annotations: key
     When attribute(name) set owns attribute type: abbreviation
     When put attribute type: real-name, with value type: string
     When attribute(real-name) set abstract: true
     When attribute(real-name) set supertype: name
-    Then attribute(real-name) get owns key types contain:
+    Then attribute(real-name) get owns types with annotations: key; contain:
       | hash |
     Then attribute(real-name) get owns attribute types contain:
       | hash         |
       | abbreviation |
     When transaction commits
     When session opens transaction of type: write
-    Then attribute(real-name) get owns key types contain:
+    Then attribute(real-name) get owns types with annotations: key; contain:
       | hash |
     Then attribute(real-name) get owns attribute types contain:
       | hash         |
@@ -586,12 +586,12 @@ Feature: Concept Attribute Type
     When attribute(last-name) set supertype: real-name
     When transaction commits
     When session opens transaction of type: read
-    Then attribute(real-name) get owns key types contain:
+    Then attribute(real-name) get owns types with annotations: key; contain:
       | hash |
     Then attribute(real-name) get owns attribute types contain:
       | hash         |
       | abbreviation |
-    Then attribute(last-name) get owns key types contain:
+    Then attribute(last-name) get owns types with annotations: key; contain:
       | hash |
     Then attribute(last-name) get owns attribute types contain:
       | hash         |
@@ -661,20 +661,20 @@ Feature: Concept Attribute Type
     When put entity type: company
     When entity(company) set owns attribute type: email
     When put entity type: person
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: email, with annotations: key
     Then attribute(email) get attribute owners contain:
       | company |
       | person  |
     Then attribute(email) get attribute owners explicit contain:
       | company |
       | person  |
-    Then attribute(email) get key owners contain:
+    Then attribute(email) get owners with annotations: key; contain:
       | person |
-    Then attribute(email) get key owners explicit contain:
+    Then attribute(email) get owners explicit with annotations: key; contain:
       | person |
-    Then attribute(email) get key owners do not contain:
+    Then attribute(email) get owners with annotations: key; do not contain:
       | company |
-    Then attribute(email) get key owners explicit do not contain:
+    Then attribute(email) get owners explicit with annotations: key; do not contain:
       | company |
     Then transaction commits
     When session opens transaction of type: write
@@ -684,13 +684,13 @@ Feature: Concept Attribute Type
     Then attribute(email) get attribute owners explicit contain:
       | company |
       | person  |
-    Then attribute(email) get key owners contain:
+    Then attribute(email) get owners with annotations: key; contain:
       | person |
-    Then attribute(email) get key owners explicit contain:
+    Then attribute(email) get owners explicit with annotations: key; contain:
       | person |
-    Then attribute(email) get key owners do not contain:
+    Then attribute(email) get owners with annotations: key; do not contain:
       | company |
-    Then attribute(email) get key owners explicit do not contain:
+    Then attribute(email) get owners explicit with annotations: key; do not contain:
       | company |
 
   Scenario: Attribute types with value type string can unset their regular expression

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -324,10 +324,8 @@ Feature: Concept Entity Type
     When entity(person) set owns attribute type: age, with annotations: key
     When entity(person) set owns attribute type: name, with annotations: key
     When entity(person) set owns attribute type: timestamp, with annotations: key
-    When entity(person) set owns attribute type: timestamp, with annotations: key
+    Then entity(person) set owns attribute type: is-open, with annotations: key
     When transaction commits
-    When session opens transaction of type: write
-    Then entity(person) set owns attribute type: is-open, with annotations: key; throws exception
     When session opens transaction of type: write
     Then entity(person) set owns attribute type: rating, with annotations: key; throws exception
 
@@ -646,7 +644,7 @@ Feature: Concept Entity Type
     When entity(customer) set abstract: true
     When entity(customer) set supertype: person
     When entity(customer) set owns attribute type: reference, with annotations: key
-    When entity(customer) set owns attribute type: work-email as email, with annotations: key
+    When entity(customer) set owns attribute type: work-email as email
     When entity(customer) set owns attribute type: rating
     When entity(customer) set owns attribute type: nick-name as name
     Then entity(customer) get owns overridden attribute(work-email) get label: email
@@ -725,7 +723,7 @@ Feature: Concept Entity Type
     When attribute(points) set supertype: rating
     When put entity type: subscriber
     When entity(subscriber) set supertype: customer
-    When entity(subscriber) set owns attribute type: license as reference, with annotations: key
+    When entity(subscriber) set owns attribute type: license as reference
     When entity(subscriber) set owns attribute type: points as rating
     When transaction commits
     When session opens transaction of type: read
@@ -856,7 +854,7 @@ Feature: Concept Entity Type
     When session opens transaction of type: write
     Then entity(person) set owns attribute type: email
 
-  Scenario: Entity types can re-override keys as keys
+  Scenario: Entity types can re-override keys
     When put attribute type: email, with value type: string
     When attribute(email) set abstract: true
     When put attribute type: work-email, with value type: string
@@ -867,11 +865,11 @@ Feature: Concept Entity Type
     When put entity type: customer
     When entity(customer) set abstract: true
     When entity(customer) set supertype: person
-    When entity(customer) set owns attribute type: work-email as email, with annotations: key
+    When entity(customer) set owns attribute type: work-email as email
     Then entity(customer) get owns overridden attribute(work-email) get label: email
     When transaction commits
     When session opens transaction of type: write
-    When entity(customer) set owns attribute type: work-email as email, with annotations: key
+    When entity(customer) set owns attribute type: work-email as email
     Then entity(customer) get owns overridden attribute(work-email) get label: email
 
   Scenario: Entity types can re-override attributes as attributes
@@ -1036,18 +1034,6 @@ Feature: Concept Entity Type
     Then entity(person) set owns attribute type: email as username, with annotations: key; throws exception
     When session opens transaction of type: write
     Then entity(person) set owns attribute type: first-name as name; throws exception
-
-  Scenario: Entity types cannot override inherited keys as attributes
-    When put attribute type: username, with value type: string
-    When attribute(username) set abstract: true
-    When put attribute type: email, with value type: string
-    When attribute(email) set supertype: username
-    When put entity type: person
-    When entity(person) set abstract: true
-    When entity(person) set owns attribute type: username, with annotations: key
-    When put entity type: customer
-    When entity(customer) set supertype: person
-    Then entity(customer) set owns attribute type: email as username; throws exception
 
   Scenario: Entity types cannot override inherited keys and attributes other than with their subtypes
     When put attribute type: username, with value type: string

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -245,14 +245,14 @@ Feature: Concept Entity Type
     When put attribute type: email, with value type: string
     When put attribute type: username, with value type: string
     When put entity type: person
-    When entity(person) set owns key type: email
-    When entity(person) set owns key type: username
-    Then entity(person) get owns key types contain:
+    When entity(person) set owns attribute type: email, with annotations: key
+    When entity(person) set owns attribute type: username, with annotations: key
+    Then entity(person) get owns types with annotations: key; contain:
       | email    |
       | username |
     When transaction commits
     When session opens transaction of type: read
-    Then entity(person) get owns key types contain:
+    Then entity(person) get owns types with annotations: key; contain:
       | email    |
       | username |
 
@@ -260,7 +260,7 @@ Feature: Concept Entity Type
     When put attribute type: email, with value type: string
     When put attribute type: username, with value type: string
     When put entity type: person
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: username, with annotations: key
     Then transaction commits
     When connection close all sessions
     When connection open data session for database: typedb
@@ -271,7 +271,7 @@ Feature: Concept Entity Type
     When connection close all sessions
     When connection open schema session for database: typedb
     When session opens transaction of type: write
-    When entity(person) set owns key type: email; throws exception
+    When entity(person) set owns attribute type: email, with annotations: key; throws exception
     When session opens transaction of type: write
     When entity(person) set owns attribute type: email
     Then transaction commits
@@ -288,13 +288,13 @@ Feature: Concept Entity Type
     When connection close all sessions
     When connection open schema session for database: typedb
     When session opens transaction of type: write
-    When entity(person) set owns key type: email
-    Then entity(person) get owns key types contain:
+    When entity(person) set owns attribute type: email, with annotations: key
+    Then entity(person) get owns types with annotations: key; contain:
       | email    |
       | username |
     Then transaction commits
     When session opens transaction of type: read
-    Then entity(person) get owns key types contain:
+    Then entity(person) get owns types with annotations: key; contain:
       | email    |
       | username |
 
@@ -302,15 +302,15 @@ Feature: Concept Entity Type
     When put attribute type: email, with value type: string
     When put attribute type: username, with value type: string
     When put entity type: person
-    When entity(person) set owns key type: email
-    When entity(person) set owns key type: username
-    When entity(person) unset owns key type: email
-    Then entity(person) get owns key types do not contain:
+    When entity(person) set owns attribute type: email, with annotations: key
+    When entity(person) set owns attribute type: username, with annotations: key
+    When entity(person) unset owns attribute type: email
+    Then entity(person) get owns types with annotations: key; do not contain:
       | email |
     When transaction commits
     When session opens transaction of type: write
-    When entity(person) unset owns key type: username
-    Then entity(person) get owns key types do not contain:
+    When entity(person) unset owns attribute type: username
+    Then entity(person) get owns types with annotations: key; do not contain:
       | email    |
       | username |
 
@@ -321,15 +321,15 @@ Feature: Concept Entity Type
     When put attribute type: name, with value type: string
     When put attribute type: timestamp, with value type: datetime
     When put entity type: person
-    When entity(person) set owns key type: age
-    When entity(person) set owns key type: name
-    When entity(person) set owns key type: timestamp
-    When entity(person) set owns key type: timestamp
+    When entity(person) set owns attribute type: age, with annotations: key
+    When entity(person) set owns attribute type: name, with annotations: key
+    When entity(person) set owns attribute type: timestamp, with annotations: key
+    When entity(person) set owns attribute type: timestamp, with annotations: key
     When transaction commits
     When session opens transaction of type: write
-    Then entity(person) set owns key type: is-open; throws exception
+    Then entity(person) set owns attribute type: is-open, with annotations: key; throws exception
     When session opens transaction of type: write
-    Then entity(person) set owns key type: rating; throws exception
+    Then entity(person) set owns attribute type: rating, with annotations: key; throws exception
 
   Scenario: Entity types can have attributes
     When put attribute type: name, with value type: string
@@ -385,11 +385,11 @@ Feature: Concept Entity Type
     When put attribute type: name, with value type: string
     When put attribute type: age, with value type: long
     When put entity type: person
-    When entity(person) set owns key type: email
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: email, with annotations: key
+    When entity(person) set owns attribute type: username, with annotations: key
     When entity(person) set owns attribute type: name
     When entity(person) set owns attribute type: age
-    Then entity(person) get owns key types contain:
+    Then entity(person) get owns types with annotations: key; contain:
       | email    |
       | username |
     Then entity(person) get owns attribute types contain:
@@ -399,7 +399,7 @@ Feature: Concept Entity Type
       | age      |
     When transaction commits
     When session opens transaction of type: read
-    Then entity(person) get owns key types contain:
+    Then entity(person) get owns types with annotations: key; contain:
       | email    |
       | username |
     Then entity(person) get owns attribute types contain:
@@ -414,18 +414,18 @@ Feature: Concept Entity Type
     When put attribute type: reference, with value type: string
     When put attribute type: rating, with value type: double
     When put entity type: person
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: email, with annotations: key
     When entity(person) set owns attribute type: name
     When put entity type: customer
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: reference
+    When entity(customer) set owns attribute type: reference, with annotations: key
     When entity(customer) set owns attribute type: rating
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | email     |
       | reference |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | email     |
     Then entity(customer) get owns attribute types contain:
       | email     |
@@ -440,12 +440,12 @@ Feature: Concept Entity Type
       | name      |
     When transaction commits
     When session opens transaction of type: write
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | email     |
       | reference |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | email     |
     Then entity(customer) get owns attribute types contain:
       | email     |
@@ -462,16 +462,16 @@ Feature: Concept Entity Type
     When put attribute type: points, with value type: double
     When put entity type: subscriber
     When entity(subscriber) set supertype: customer
-    When entity(subscriber) set owns key type: license
+    When entity(subscriber) set owns attribute type: license, with annotations: key
     When entity(subscriber) set owns attribute type: points
     When transaction commits
     When session opens transaction of type: read
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | email     |
       | reference |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | email     |
     Then entity(customer) get owns attribute types contain:
       | email     |
@@ -484,13 +484,13 @@ Feature: Concept Entity Type
     Then entity(customer) get owns explicit attribute types do not contain:
       | email     |
       | name      |
-    Then entity(subscriber) get owns key types contain:
+    Then entity(subscriber) get owns types with annotations: key; contain:
       | email     |
       | reference |
       | license   |
-    Then entity(subscriber) get owns explicit key types contain:
+    Then entity(subscriber) get owns explicit types with annotations: key; contain:
       | license   |
-    Then entity(subscriber) get owns explicit key types do not contain:
+    Then entity(subscriber) get owns explicit types with annotations: key; do not contain:
       | email     |
       | reference |
     Then entity(subscriber) get owns attribute types contain:
@@ -522,19 +522,19 @@ Feature: Concept Entity Type
     When attribute(rating) set supertype: score
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: username, with annotations: key
     When entity(person) set owns attribute type: score
     When put entity type: customer
     When entity(customer) set abstract: true
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: reference
+    When entity(customer) set owns attribute type: reference, with annotations: key
     When entity(customer) set owns attribute type: rating
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username  |
       | reference |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | username  |
     Then entity(customer) get owns attribute types contain:
       | username  |
@@ -549,12 +549,12 @@ Feature: Concept Entity Type
       | score     |
     When transaction commits
     When session opens transaction of type: write
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username  |
       | reference |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | username  |
     Then entity(customer) get owns attribute types contain:
       | username  |
@@ -574,16 +574,16 @@ Feature: Concept Entity Type
     When put entity type: subscriber
     When entity(subscriber) set abstract: true
     When entity(subscriber) set supertype: customer
-    When entity(subscriber) set owns key type: license
+    When entity(subscriber) set owns attribute type: license, with annotations: key
     When entity(subscriber) set owns attribute type: points
     When transaction commits
     When session opens transaction of type: read
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username  |
       | reference |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | username  |
     Then entity(customer) get owns attribute types contain:
       | username  |
@@ -596,13 +596,13 @@ Feature: Concept Entity Type
     Then entity(customer) get owns explicit attribute types do not contain:
       | username  |
       | score     |
-    Then entity(subscriber) get owns key types contain:
+    Then entity(subscriber) get owns types with annotations: key; contain:
       | username  |
       | reference |
       | license   |
-    Then entity(subscriber) get owns explicit key types contain:
+    Then entity(subscriber) get owns explicit types with annotations: key; contain:
       | license   |
-    Then entity(subscriber) get owns explicit key types do not contain:
+    Then entity(subscriber) get owns explicit types with annotations: key; do not contain:
       | username  |
       | reference |
     Then entity(subscriber) get owns attribute types contain:
@@ -638,29 +638,29 @@ Feature: Concept Entity Type
     When attribute(rating) set abstract: true
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: username
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: username, with annotations: key
+    When entity(person) set owns attribute type: email, with annotations: key
     When entity(person) set owns attribute type: name
     When entity(person) set owns attribute type: age
     When put entity type: customer
     When entity(customer) set abstract: true
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: reference
-    When entity(customer) set owns key type: work-email as email
+    When entity(customer) set owns attribute type: reference, with annotations: key
+    When entity(customer) set owns attribute type: work-email as email, with annotations: key
     When entity(customer) set owns attribute type: rating
     When entity(customer) set owns attribute type: nick-name as name
     Then entity(customer) get owns overridden attribute(work-email) get label: email
     Then entity(customer) get owns overridden attribute(nick-name) get label: name
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username   |
       | reference  |
       | work-email |
-    Then entity(customer) get owns key types do not contain:
+    Then entity(customer) get owns types with annotations: key; do not contain:
       | email |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference  |
       | work-email |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | username   |
       | email      |
     Then entity(customer) get owns attribute types contain:
@@ -687,16 +687,16 @@ Feature: Concept Entity Type
     When session opens transaction of type: write
     Then entity(customer) get owns overridden attribute(work-email) get label: email
     Then entity(customer) get owns overridden attribute(nick-name) get label: name
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username   |
       | reference  |
       | work-email |
-    Then entity(customer) get owns key types do not contain:
+    Then entity(customer) get owns types with annotations: key; do not contain:
       | email |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference  |
       | work-email |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | username   |
       | email      |
     Then entity(customer) get owns attribute types contain:
@@ -725,20 +725,20 @@ Feature: Concept Entity Type
     When attribute(points) set supertype: rating
     When put entity type: subscriber
     When entity(subscriber) set supertype: customer
-    When entity(subscriber) set owns key type: license as reference
+    When entity(subscriber) set owns attribute type: license as reference, with annotations: key
     When entity(subscriber) set owns attribute type: points as rating
     When transaction commits
     When session opens transaction of type: read
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username   |
       | reference  |
       | work-email |
-    Then entity(customer) get owns key types do not contain:
+    Then entity(customer) get owns types with annotations: key; do not contain:
       | email |
-    Then entity(customer) get owns explicit key types contain:
+    Then entity(customer) get owns explicit types with annotations: key; contain:
       | reference  |
       | work-email |
-    Then entity(customer) get owns explicit key types do not contain:
+    Then entity(customer) get owns explicit types with annotations: key; do not contain:
       | username   |
       | email      |
     Then entity(customer) get owns attribute types contain:
@@ -763,16 +763,16 @@ Feature: Concept Entity Type
       | name       |
     Then entity(subscriber) get owns overridden attribute(license) get label: reference
     Then entity(subscriber) get owns overridden attribute(points) get label: rating
-    Then entity(subscriber) get owns key types contain:
+    Then entity(subscriber) get owns types with annotations: key; contain:
       | username   |
       | license    |
       | work-email |
-    Then entity(subscriber) get owns key types do not contain:
+    Then entity(subscriber) get owns types with annotations: key; do not contain:
       | email     |
       | reference |
-    Then entity(subscriber) get owns explicit key types contain:
+    Then entity(subscriber) get owns explicit types with annotations: key; contain:
       | license    |
-    Then entity(subscriber) get owns explicit key types do not contain:
+    Then entity(subscriber) get owns explicit types with annotations: key; do not contain:
       | username   |
       | work-email |
       | email     |
@@ -812,11 +812,11 @@ Feature: Concept Entity Type
     When entity(person) set owns attribute type: name
     When put entity type: customer
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: username as name
+    When entity(customer) set owns attribute type: username as name, with annotations: key
     Then entity(customer) get owns overridden attribute(username) get label: name
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username |
-    Then entity(customer) get owns key types do not contain:
+    Then entity(customer) get owns types with annotations: key; do not contain:
       | name |
     Then entity(customer) get owns attribute types contain:
       | username |
@@ -825,9 +825,9 @@ Feature: Concept Entity Type
     When transaction commits
     When session opens transaction of type: read
     Then entity(customer) get owns overridden attribute(username) get label: name
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | username |
-    Then entity(customer) get owns key types do not contain:
+    Then entity(customer) get owns types with annotations: key; do not contain:
       | name |
     Then entity(customer) get owns attribute types contain:
       | username |
@@ -838,12 +838,12 @@ Feature: Concept Entity Type
     When put attribute type: name, with value type: string
     When put attribute type: email, with value type: string
     When put entity type: person
-    When entity(person) set owns key type: name
-    When entity(person) set owns key type: email
-    Then entity(person) set owns key type: name
+    When entity(person) set owns attribute type: name, with annotations: key
+    When entity(person) set owns attribute type: email, with annotations: key
+    Then entity(person) set owns attribute type: name, with annotations: key
     When transaction commits
     When session opens transaction of type: write
-    Then entity(person) set owns key type: email
+    Then entity(person) set owns attribute type: email, with annotations: key
 
   Scenario: Entity types can redeclare attributes as attributes
     When put attribute type: name, with value type: string
@@ -863,15 +863,15 @@ Feature: Concept Entity Type
     When attribute(work-email) set supertype: email
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: email, with annotations: key
     When put entity type: customer
     When entity(customer) set abstract: true
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: work-email as email
+    When entity(customer) set owns attribute type: work-email as email, with annotations: key
     Then entity(customer) get owns overridden attribute(work-email) get label: email
     When transaction commits
     When session opens transaction of type: write
-    When entity(customer) set owns key type: work-email as email
+    When entity(customer) set owns attribute type: work-email as email, with annotations: key
     Then entity(customer) get owns overridden attribute(work-email) get label: email
 
   Scenario: Entity types can re-override attributes as attributes
@@ -896,8 +896,8 @@ Feature: Concept Entity Type
     When put attribute type: name, with value type: string
     When put attribute type: email, with value type: string
     When put entity type: person
-    When entity(person) set owns key type: name
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: name, with annotations: key
+    When entity(person) set owns attribute type: email, with annotations: key
     Then entity(person) set owns attribute type: name
     When transaction commits
     When session opens transaction of type: write
@@ -909,10 +909,10 @@ Feature: Concept Entity Type
     When put entity type: person
     When entity(person) set owns attribute type: name
     When entity(person) set owns attribute type: email
-    Then entity(person) set owns key type: name
+    Then entity(person) set owns attribute type: name, with annotations: key
     When transaction commits
     When session opens transaction of type: write
-    Then entity(person) set owns key type: email
+    Then entity(person) set owns attribute type: email, with annotations: key
 
   Scenario: Entity types can redeclare inherited attributes as keys (which will override)
     When put attribute type: email, with value type: string
@@ -921,19 +921,19 @@ Feature: Concept Entity Type
     Then entity(person) get owns overridden attribute(email) is null: true
     When put entity type: customer
     When entity(customer) set supertype: person
-    Then entity(customer) set owns key type: email
+    Then entity(customer) set owns attribute type: email, with annotations: key
     Then entity(customer) get owns overridden attribute(email) is null: false
     Then entity(customer) get owns overridden attribute(email) get label: email
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | email |
     When transaction commits
     When session opens transaction of type: write
-    Then entity(customer) get owns key types contain:
+    Then entity(customer) get owns types with annotations: key; contain:
       | email |
     When put entity type: subscriber
     When entity(subscriber) set supertype: person
-    Then entity(subscriber) set owns key type: email
-    Then entity(subscriber) get owns key types contain:
+    Then entity(subscriber) set owns attribute type: email, with annotations: key
+    Then entity(subscriber) get owns types with annotations: key; contain:
       | email |
 
   Scenario: Entity types cannot redeclare inherited attributes as attributes
@@ -949,12 +949,12 @@ Feature: Concept Entity Type
     When put attribute type: email, with value type: string
     When put attribute type: name, with value type: string
     When put entity type: person
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: email, with annotations: key
     When put entity type: customer
     When entity(customer) set supertype: person
     When transaction commits
     When session opens transaction of type: write
-    Then entity(customer) set owns key type: email; throws exception
+    Then entity(customer) set owns attribute type: email, with annotations: key; throws exception
     When session opens transaction of type: write
     Then entity(customer) set owns attribute type: email; throws exception
 
@@ -965,13 +965,13 @@ Feature: Concept Entity Type
     When attribute(customer-email) set supertype: email
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: email, with annotations: key
     When put entity type: customer
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: customer-email
+    When entity(customer) set owns attribute type: customer-email, with annotations: key
     When put entity type: subscriber
     When entity(subscriber) set supertype: customer
-    Then entity(subscriber) set owns key type: email; throws exception
+    Then entity(subscriber) set owns attribute type: email, with annotations: key; throws exception
 
   Scenario: Entity types cannot redeclare overridden key attribute types
     When put attribute type: email, with value type: string
@@ -980,13 +980,13 @@ Feature: Concept Entity Type
     When attribute(customer-email) set supertype: email
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: email
+    When entity(person) set owns attribute type: email, with annotations: key
     When put entity type: customer
     When entity(customer) set supertype: person
-    When entity(customer) set owns key type: customer-email
+    When entity(customer) set owns attribute type: customer-email, with annotations: key
     When put entity type: subscriber
     When entity(subscriber) set supertype: customer
-    Then entity(subscriber) set owns key type: customer-email; throws exception
+    Then entity(subscriber) set owns attribute type: customer-email, with annotations: key; throws exception
 
   Scenario: Entity types cannot redeclare inherited owns attribute types
     When put attribute type: name, with value type: string
@@ -1029,11 +1029,11 @@ Feature: Concept Entity Type
     When attribute(first-name) set supertype: name
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: username, with annotations: key
     When entity(person) set owns attribute type: name
     When transaction commits
     When session opens transaction of type: write
-    Then entity(person) set owns key type: email as username; throws exception
+    Then entity(person) set owns attribute type: email as username, with annotations: key; throws exception
     When session opens transaction of type: write
     Then entity(person) set owns attribute type: first-name as name; throws exception
 
@@ -1044,7 +1044,7 @@ Feature: Concept Entity Type
     When attribute(email) set supertype: username
     When put entity type: person
     When entity(person) set abstract: true
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: username, with annotations: key
     When put entity type: customer
     When entity(customer) set supertype: person
     Then entity(customer) set owns attribute type: email as username; throws exception
@@ -1055,13 +1055,13 @@ Feature: Concept Entity Type
     When put attribute type: reference, with value type: string
     When put attribute type: rating, with value type: double
     When put entity type: person
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: username, with annotations: key
     When entity(person) set owns attribute type: name
     When put entity type: customer
     When entity(customer) set supertype: person
     When transaction commits
     When session opens transaction of type: write
-    Then entity(customer) set owns key type: reference as username; throws exception
+    Then entity(customer) set owns attribute type: reference as username, with annotations: key; throws exception
     When session opens transaction of type: write
     Then entity(customer) set owns attribute type: rating as name; throws exception
 

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -552,8 +552,7 @@ Feature: Concept Relation Type and Role Type
   Scenario: Relation types cannot have keys of attributes that are not keyable
     When put attribute type: is-permanent, with value type: boolean
     When put relation type: employment
-    Then relation(employment) set owns attribute type: is-permanent, with annotations: key; throws exception
-    When session opens transaction of type: write
+    Then relation(employment) set owns attribute type: is-permanent, with annotations: key
     When put attribute type: salary, with value type: double
     When put relation type: employment
     Then relation(employment) set owns attribute type: salary, with annotations: key; throws exception
@@ -794,7 +793,7 @@ Feature: Concept Relation Type and Role Type
     When put relation type: contractor-employment
     When relation(contractor-employment) set abstract: true
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference, with annotations: key
+    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference
     When relation(contractor-employment) set owns attribute type: contractor-hours as employment-hours
     Then relation(contractor-employment) get owns types with annotations: key; contain:
       | contractor-reference |
@@ -826,7 +825,7 @@ Feature: Concept Relation Type and Role Type
     When relation(parttime-employment) set supertype: contractor-employment
     When relation(parttime-employment) set relates role: parttime-employer as employer
     When relation(parttime-employment) set relates role: parttime-employee as employee
-    When relation(parttime-employment) set owns attribute type: parttime-reference as contractor-reference, with annotations: key
+    When relation(parttime-employment) set owns attribute type: parttime-reference as contractor-reference
     When relation(parttime-employment) set owns attribute type: parttime-hours as contractor-hours
     Then relation(parttime-employment) get owns types with annotations: key; contain:
       | parttime-reference |
@@ -957,7 +956,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference, with annotations: key
+    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
     Then relation(parttime-employment) set owns attribute type: contractor-reference, with annotations: key; throws exception
@@ -1011,20 +1010,6 @@ Feature: Concept Relation Type and Role Type
     Then relation(employment) set owns attribute type: social-security-number as reference, with annotations: key; throws exception
     When session opens transaction of type: write
     Then relation(employment) set owns attribute type: max-hours as hours; throws exception
-
-  Scenario: Relation types cannot override inherited keys as attributes
-    When put attribute type: employment-reference, with value type: string
-    When attribute(employment-reference) set abstract: true
-    When put attribute type: contractor-reference, with value type: string
-    When attribute(contractor-reference) set supertype: employment-reference
-    When put relation type: employment
-    When relation(employment) set abstract: true
-    When relation(employment) set relates role: employer
-    When relation(employment) set relates role: employee
-    When relation(employment) set owns attribute type: employment-reference, with annotations: key
-    When put relation type: contractor-employment
-    When relation(contractor-employment) set supertype: employment
-    Then relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference; throws exception
 
   Scenario: Relation types cannot override inherited keys and attributes other than with their subtypes
     When put attribute type: employment-reference, with value type: string

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -513,12 +513,12 @@ Feature: Concept Relation Type and Role Type
     When put attribute type: license, with value type: string
     When put relation type: marriage
     When relation(marriage) set relates role: spouse
-    When relation(marriage) set owns key type: license
-    Then relation(marriage) get owns key types contain:
+    When relation(marriage) set owns attribute type: license, with annotations: key
+    Then relation(marriage) get owns types with annotations: key; contain:
       | license |
     When transaction commits
     When session opens transaction of type: read
-    Then relation(marriage) get owns key types contain:
+    Then relation(marriage) get owns types with annotations: key; contain:
       | license |
 
   Scenario: Relation types can unset keys
@@ -526,15 +526,15 @@ Feature: Concept Relation Type and Role Type
     When put attribute type: certificate, with value type: string
     When put relation type: marriage
     When relation(marriage) set relates role: spouse
-    When relation(marriage) set owns key type: license
-    When relation(marriage) set owns key type: certificate
-    When relation(marriage) unset owns key type: license
-    Then relation(marriage) get owns key types do not contain:
+    When relation(marriage) set owns attribute type: license, with annotations: key
+    When relation(marriage) set owns attribute type: certificate, with annotations: key
+    When relation(marriage) unset owns attribute type: license
+    Then relation(marriage) get owns types with annotations: key; do not contain:
       | license |
     When transaction commits
     When session opens transaction of type: write
-    When relation(marriage) unset owns key type: certificate
-    Then relation(marriage) get owns key types do not contain:
+    When relation(marriage) unset owns attribute type: certificate
+    Then relation(marriage) get owns types with annotations: key; do not contain:
       | license     |
       | certificate |
 
@@ -545,18 +545,18 @@ Feature: Concept Relation Type and Role Type
     When put attribute type: reference, with value type: string
     When put attribute type: start-date, with value type: datetime
     When put relation type: employment
-    When relation(employment) set owns key type: contract-years
-    When relation(employment) set owns key type: reference
-    When relation(employment) set owns key type: start-date
+    When relation(employment) set owns attribute type: contract-years, with annotations: key
+    When relation(employment) set owns attribute type: reference, with annotations: key
+    When relation(employment) set owns attribute type: start-date, with annotations: key
 
   Scenario: Relation types cannot have keys of attributes that are not keyable
     When put attribute type: is-permanent, with value type: boolean
     When put relation type: employment
-    Then relation(employment) set owns key type: is-permanent; throws exception
+    Then relation(employment) set owns attribute type: is-permanent, with annotations: key; throws exception
     When session opens transaction of type: write
     When put attribute type: salary, with value type: double
     When put relation type: employment
-    Then relation(employment) set owns key type: salary; throws exception
+    Then relation(employment) set owns attribute type: salary, with annotations: key; throws exception
 
   Scenario: Relation types can have attributes
     When put attribute type: date, with value type: datetime
@@ -598,11 +598,11 @@ Feature: Concept Relation Type and Role Type
     When put attribute type: religion, with value type: string
     When put relation type: marriage
     When relation(marriage) set relates role: wife
-    When relation(marriage) set owns key type: license
-    When relation(marriage) set owns key type: certificate
+    When relation(marriage) set owns attribute type: license, with annotations: key
+    When relation(marriage) set owns attribute type: certificate, with annotations: key
     When relation(marriage) set owns attribute type: date
     When relation(marriage) set owns attribute type: religion
-    Then relation(marriage) get owns key types contain:
+    Then relation(marriage) get owns types with annotations: key; contain:
       | license     |
       | certificate |
     Then relation(marriage) get owns attribute types contain:
@@ -612,7 +612,7 @@ Feature: Concept Relation Type and Role Type
       | religion    |
     When transaction commits
     When session opens transaction of type: read
-    Then relation(marriage) get owns key types contain:
+    Then relation(marriage) get owns types with annotations: key; contain:
       | license     |
       | certificate |
     Then relation(marriage) get owns attribute types contain:
@@ -629,13 +629,13 @@ Feature: Concept Relation Type and Role Type
     When put relation type: employment
     When relation(employment) set relates role: employee
     When relation(employment) set relates role: employer
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When relation(employment) set owns attribute type: employment-hours
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set owns key type: contractor-reference
+    When relation(contractor-employment) set owns attribute type: contractor-reference, with annotations: key
     When relation(contractor-employment) set owns attribute type: contractor-hours
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
     Then relation(contractor-employment) get owns attribute types contain:
@@ -645,7 +645,7 @@ Feature: Concept Relation Type and Role Type
       | contractor-hours     |
     When transaction commits
     When session opens transaction of type: write
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
     Then relation(contractor-employment) get owns attribute types contain:
@@ -657,9 +657,9 @@ Feature: Concept Relation Type and Role Type
     When put attribute type: parttime-hours, with value type: long
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
-    When relation(parttime-employment) set owns key type: parttime-reference
+    When relation(parttime-employment) set owns attribute type: parttime-reference, with annotations: key
     When relation(parttime-employment) set owns attribute type: parttime-hours
-    Then relation(parttime-employment) get owns key types contain:
+    Then relation(parttime-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
       | parttime-reference   |
@@ -672,7 +672,7 @@ Feature: Concept Relation Type and Role Type
       | parttime-hours       |
     When transaction commits
     When session opens transaction of type: read
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
     Then relation(contractor-employment) get owns attribute types contain:
@@ -680,7 +680,7 @@ Feature: Concept Relation Type and Role Type
       | contractor-reference |
       | employment-hours     |
       | contractor-hours     |
-    Then relation(parttime-employment) get owns key types contain:
+    Then relation(parttime-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
       | parttime-reference   |
@@ -707,14 +707,14 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set abstract: true
     When relation(employment) set relates role: employee
     When relation(employment) set relates role: employer
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When relation(employment) set owns attribute type: employment-hours
     When put relation type: contractor-employment
     When relation(contractor-employment) set abstract: true
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set owns key type: contractor-reference
+    When relation(contractor-employment) set owns attribute type: contractor-reference, with annotations: key
     When relation(contractor-employment) set owns attribute type: contractor-hours
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
     Then relation(contractor-employment) get owns attribute types contain:
@@ -724,7 +724,7 @@ Feature: Concept Relation Type and Role Type
       | contractor-hours     |
     When transaction commits
     When session opens transaction of type: write
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
     Then relation(contractor-employment) get owns attribute types contain:
@@ -739,9 +739,9 @@ Feature: Concept Relation Type and Role Type
     When put relation type: parttime-employment
     When relation(parttime-employment) set abstract: true
     When relation(parttime-employment) set supertype: contractor-employment
-    When relation(parttime-employment) set owns key type: parttime-reference
+    When relation(parttime-employment) set owns attribute type: parttime-reference, with annotations: key
     When relation(parttime-employment) set owns attribute type: parttime-hours
-    Then relation(parttime-employment) get owns key types contain:
+    Then relation(parttime-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
       | parttime-reference   |
@@ -754,7 +754,7 @@ Feature: Concept Relation Type and Role Type
       | parttime-hours       |
     When transaction commits
     When session opens transaction of type: read
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
     Then relation(contractor-employment) get owns attribute types contain:
@@ -762,7 +762,7 @@ Feature: Concept Relation Type and Role Type
       | contractor-reference |
       | employment-hours     |
       | contractor-hours     |
-    Then relation(parttime-employment) get owns key types contain:
+    Then relation(parttime-employment) get owns types with annotations: key; contain:
       | employment-reference |
       | contractor-reference |
       | parttime-reference   |
@@ -789,16 +789,16 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set abstract: true
     When relation(employment) set relates role: employee
     When relation(employment) set relates role: employer
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When relation(employment) set owns attribute type: employment-hours
     When put relation type: contractor-employment
     When relation(contractor-employment) set abstract: true
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set owns key type: contractor-reference as employment-reference
+    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference, with annotations: key
     When relation(contractor-employment) set owns attribute type: contractor-hours as employment-hours
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | contractor-reference |
-    Then relation(contractor-employment) get owns key types do not contain:
+    Then relation(contractor-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
     Then relation(contractor-employment) get owns attribute types contain:
       | contractor-reference |
@@ -808,9 +808,9 @@ Feature: Concept Relation Type and Role Type
       | employment-hours     |
     When transaction commits
     When session opens transaction of type: write
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | contractor-reference |
-    Then relation(contractor-employment) get owns key types do not contain:
+    Then relation(contractor-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
     Then relation(contractor-employment) get owns attribute types contain:
       | contractor-reference |
@@ -826,18 +826,18 @@ Feature: Concept Relation Type and Role Type
     When relation(parttime-employment) set supertype: contractor-employment
     When relation(parttime-employment) set relates role: parttime-employer as employer
     When relation(parttime-employment) set relates role: parttime-employee as employee
-    When relation(parttime-employment) set owns key type: parttime-reference as contractor-reference
+    When relation(parttime-employment) set owns attribute type: parttime-reference as contractor-reference, with annotations: key
     When relation(parttime-employment) set owns attribute type: parttime-hours as contractor-hours
-    Then relation(parttime-employment) get owns key types contain:
+    Then relation(parttime-employment) get owns types with annotations: key; contain:
       | parttime-reference |
     Then relation(parttime-employment) get owns attribute types contain:
       | parttime-reference |
       | parttime-hours     |
     When transaction commits
     When session opens transaction of type: read
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | contractor-reference |
-    Then relation(contractor-employment) get owns key types do not contain:
+    Then relation(contractor-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
     Then relation(contractor-employment) get owns attribute types contain:
       | contractor-reference |
@@ -845,15 +845,15 @@ Feature: Concept Relation Type and Role Type
     Then relation(contractor-employment) get owns attribute types do not contain:
       | employment-reference |
       | employment-hours     |
-    Then relation(parttime-employment) get owns key types contain:
+    Then relation(parttime-employment) get owns types with annotations: key; contain:
       | parttime-reference |
-    Then relation(parttime-employment) get owns key types do not contain:
+    Then relation(parttime-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
       | contractor-reference |
     Then relation(parttime-employment) get owns attribute types contain:
       | parttime-reference |
       | parttime-hours     |
-    Then relation(parttime-employment) get owns key types do not contain:
+    Then relation(parttime-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
       | contractor-reference |
       | employment-hours     |
@@ -873,10 +873,10 @@ Feature: Concept Relation Type and Role Type
     When relation(contractor-employment) set supertype: employment
     When relation(contractor-employment) set relates role: contractor-employer as employer
     When relation(contractor-employment) set relates role: contractor-employee as employee
-    When relation(contractor-employment) set owns key type: contractor-reference as employment-reference
-    Then relation(contractor-employment) get owns key types contain:
+    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference, with annotations: key
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | contractor-reference |
-    Then relation(contractor-employment) get owns key types do not contain:
+    Then relation(contractor-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
     Then relation(contractor-employment) get owns attribute types contain:
       | contractor-reference |
@@ -884,9 +884,9 @@ Feature: Concept Relation Type and Role Type
       | employment-reference |
     When transaction commits
     When session opens transaction of type: read
-    Then relation(contractor-employment) get owns key types contain:
+    Then relation(contractor-employment) get owns types with annotations: key; contain:
       | contractor-reference |
-    Then relation(contractor-employment) get owns key types do not contain:
+    Then relation(contractor-employment) get owns types with annotations: key; do not contain:
       | employment-reference |
     Then relation(contractor-employment) get owns attribute types contain:
       | contractor-reference |
@@ -898,8 +898,8 @@ Feature: Concept Relation Type and Role Type
     When put attribute type: license, with value type: string
     When put relation type: marriage
     When relation(marriage) set relates role: spouse
-    When relation(marriage) set owns key type: date
-    When relation(marriage) set owns key type: license
+    When relation(marriage) set owns attribute type: date, with annotations: key
+    When relation(marriage) set owns attribute type: license, with annotations: key
     When relation(marriage) set owns attribute type: date
     When transaction commits
     When session opens transaction of type: write
@@ -912,10 +912,10 @@ Feature: Concept Relation Type and Role Type
     When relation(marriage) set relates role: spouse
     When relation(marriage) set owns attribute type: date
     When relation(marriage) set owns attribute type: license
-    Then relation(marriage) set owns key type: date
+    Then relation(marriage) set owns attribute type: date, with annotations: key
     When transaction commits
     When session opens transaction of type: write
-    When relation(marriage) set owns key type: license
+    When relation(marriage) set owns attribute type: license, with annotations: key
 
   Scenario: Relation types cannot redeclare inherited keys and attributes
     When put attribute type: employment-reference, with value type: string
@@ -923,13 +923,13 @@ Feature: Concept Relation Type and Role Type
     When put relation type: employment
     When relation(employment) set relates role: employee
     When relation(employment) set relates role: employer
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When relation(employment) set owns attribute type: employment-hours
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
     When transaction commits
     When session opens transaction of type: write
-    Then relation(contractor-employment) set owns key type: employment-reference; throws exception
+    Then relation(contractor-employment) set owns attribute type: employment-reference, with annotations: key; throws exception
     When session opens transaction of type: write
     Then relation(contractor-employment) set owns attribute type: employment-hours; throws exception
 
@@ -939,12 +939,12 @@ Feature: Concept Relation Type and Role Type
     When put relation type: employment
     When relation(employment) set abstract: true
     When relation(employment) set relates role: employee
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
-    Then relation(parttime-employment) set owns key type: employment-reference; throws exception
+    Then relation(parttime-employment) set owns attribute type: employment-reference, with annotations: key; throws exception
 
   Scenario: Relation types cannot redeclare overridden key attribute types
     When put attribute type: employment-reference, with value type: string
@@ -954,13 +954,13 @@ Feature: Concept Relation Type and Role Type
     When put relation type: employment
     When relation(employment) set abstract: true
     When relation(employment) set relates role: employee
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
-    When relation(contractor-employment) set owns key type: contractor-reference as employment-reference
+    When relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference, with annotations: key
     When put relation type: parttime-employment
     When relation(parttime-employment) set supertype: contractor-employment
-    Then relation(parttime-employment) set owns key type: contractor-reference; throws exception
+    Then relation(parttime-employment) set owns attribute type: contractor-reference, with annotations: key; throws exception
 
   Scenario: Relation types cannot redeclare inherited owns attribute types
     When put attribute type: employment-hours, with value type: long
@@ -1004,11 +1004,11 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set abstract: true
     When relation(employment) set relates role: employee
     When relation(employment) set relates role: employer
-    When relation(employment) set owns key type: reference
+    When relation(employment) set owns attribute type: reference, with annotations: key
     When relation(employment) set owns attribute type: hours
     When transaction commits
     When session opens transaction of type: write
-    Then relation(employment) set owns key type: social-security-number as reference; throws exception
+    Then relation(employment) set owns attribute type: social-security-number as reference, with annotations: key; throws exception
     When session opens transaction of type: write
     Then relation(employment) set owns attribute type: max-hours as hours; throws exception
 
@@ -1021,7 +1021,7 @@ Feature: Concept Relation Type and Role Type
     When relation(employment) set abstract: true
     When relation(employment) set relates role: employer
     When relation(employment) set relates role: employee
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
     Then relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference; throws exception
@@ -1034,13 +1034,13 @@ Feature: Concept Relation Type and Role Type
     When put relation type: employment
     When relation(employment) set relates role: employee
     When relation(employment) set relates role: employer
-    When relation(employment) set owns key type: employment-reference
+    When relation(employment) set owns attribute type: employment-reference, with annotations: key
     When relation(employment) set owns attribute type: employment-hours
     When put relation type: contractor-employment
     When relation(contractor-employment) set supertype: employment
     When transaction commits
     When session opens transaction of type: write
-    Then relation(contractor-employment) set owns key type: contractor-reference as employment-reference; throws exception
+    Then relation(contractor-employment) set owns attribute type: contractor-reference as employment-reference, with annotations: key; throws exception
     When session opens transaction of type: write
     Then relation(contractor-employment) set owns attribute type: contractor-hours as employment-hours; throws exception
 

--- a/concept/type/thingtype.feature
+++ b/concept/type/thingtype.feature
@@ -74,9 +74,9 @@ Feature: Concept Thing Type
     When put attribute type: birth-date, with value type: datetime
     When put relation type: marriage
     When relation(marriage) set relates role: wife
-    When relation(marriage) set owns key type: license
+    When relation(marriage) set owns attribute type: license, with annotations: key
     When put entity type: person
-    When entity(person) set owns key type: username
+    When entity(person) set owns attribute type: username, with annotations: key
     When transaction commits
     When connection close all sessions
     When connection open data session for database: typedb

--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1773,7 +1773,6 @@ Feature: TypeQL Define Query
         $p has nickname "Bob";
       };
       """
-
     Then typeql define
       """
       define
@@ -1784,6 +1783,7 @@ Feature: TypeQL Define Query
         $p has nickname "Bob";
       };
       """
+
 
   Scenario: redefining a rule and querying updates its definition
     Given typeql define

--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1267,6 +1267,30 @@ Feature: TypeQL Define Query
       define animal sub entity, abstract, abstract, abstract;
       """
 
+  ##############
+  # Annotation #
+  ##############
+
+  # 1. it should be allowed to inherit annototations without doing anything
+  Scenario: annotations are inherited
+#    When typeql define
+#      """
+#      define
+#      person sub entity, owns name;
+#      person sub entity, owns name;
+#      person sub entity, owns name;
+#      """
+#    Then transaction commits
+#
+#    When session opens transaction of type: read
+#    When get answers of typeql match
+#      """
+#      match $x type person, owns name;
+#      """
+#    Then answer size is: 1
+
+  # 2. it should not be allowed to redeclare the same annotations as those that were inherited - only specialisation is allowed just like we don't allow redeclaring inherited plays/owns/relates
+  # 3. it should not be allowed to redeclare the same annotations when overriding with 'as' - the annotations must be inherited
 
 
   ###################

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -35,7 +35,8 @@ Feature: TypeQL Insert Query
         plays employment:employee,
         owns name,
         owns age,
-        owns ref @key;
+        owns ref @key,
+        owns email @unique;
 
       company sub entity,
         plays employment:employer,
@@ -55,6 +56,9 @@ Feature: TypeQL Insert Query
 
       ref sub attribute,
         value long;
+
+      email sub attribute,
+        value string;
       """
     Given transaction commits
 
@@ -1336,11 +1340,11 @@ Parker";
 
 
 
-  ########
-  # KEYS #
-  ########
+  #################
+  # KEY OWNERSHIP #
+  #################
 
-  Scenario: a thing can be inserted with a key
+  Scenario: a thing can be inserted with a key attribute
     When typeql insert
       """
       insert $x isa person, has ref 0;
@@ -1357,7 +1361,7 @@ Parker";
       | key:ref:0 |
 
 
-  Scenario: when a type has a key, attempting to insert it without that key throws on commit
+  Scenario: when a type has a key, attempting to insert it without that key attribute throws on commit
     When typeql insert
       """
       insert $x isa person;
@@ -1365,14 +1369,14 @@ Parker";
     Then transaction commits; throws exception
 
 
-  Scenario: inserting two distinct values of the same key on a thing throws an error
+  Scenario: inserting two distinct values of the same key attribute on a thing throws an error
     Then typeql insert; throws exception
       """
       insert $x isa person, has ref 0, has ref 1;
       """
 
 
-  Scenario: instances of a key must be unique among all instances of a type
+  Scenario: instances of a key attribute must be unique among all instances of a type
     Then typeql insert; throws exception
       """
       insert
@@ -1380,7 +1384,8 @@ Parker";
       $y isa person, has ref 0;
       """
 
-  Scenario: instances of an inherited key don't have to be unique among instances of a type and its subtypes
+
+  Scenario: instances of an inherited key attribute don't have to be unique among instances of a type and its subtypes
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
@@ -1418,7 +1423,8 @@ Parker";
       insert $x isa base, has ref 0;
       """
 
-  Scenario: instances of an inherited key don't have to be unique among its subtypes
+
+  Scenario: instances of an inherited key attribute don't have to be unique among its subtypes
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
@@ -1445,7 +1451,8 @@ Parker";
       insert $y isa derived-b, has ref 0;
       """
 
-  Scenario: an error is thrown when inserting a second key on an attribute that already has one
+
+  Scenario: an error is thrown when inserting a second key attribute on an attribute that already has one
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
@@ -1471,6 +1478,136 @@ Parker";
       insert $a "john" isa name, has ref 1;
       """
 
+
+  ####################
+  # UNIQUE OWNERSHIP #
+  ####################
+
+  Scenario: a thing can be inserted with a unique attribute(s)
+    When typeql insert
+      """
+      insert $x isa person, has ref 0, has email "abc@gmail.com";
+      """
+    Then transaction commits
+
+    When session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x isa person, has email "abc@gmail.com";;
+      """
+    Then uniquely identify answer concepts
+      | x         |
+      | key:ref:0 |
+    When typeql insert
+      """
+      insert $x isa person, has ref 1, has email "abc@gmail.com", has email "xyz@gmail.com";
+      """
+    Then transaction commits
+
+    When session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x isa person, has email "abc@gmail.com", has email "xyz@gmail.com";
+      """
+    Then uniquely identify answer concepts
+      | x         |
+      | key:ref:1 |
+
+
+  Scenario: two different owners cannot own the same unique attribute
+    Then typeql insert; throws exception
+      """
+      insert
+      $x isa person, has ref 0, has email "abc@gmail.com";
+      $y isa person, has ref 1, has email "abc@gmail.com";
+      """
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      $x isa person, has ref 0, has email "abc@gmail.com";
+      """
+    Then transaction commits
+    Given session opens transaction of type: write
+    Then typeql insert; throws exception
+      """
+      insert
+      $y isa person, has ref 1, has email "abc@gmail.com";
+      """
+
+
+  Scenario: inherited uniqueness is respected
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      child sub person;
+      """
+    Given transaction commits
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert $x isa child, has email "abc@gmail.com", has email "xyz@gmail.com", has ref 0;
+      """
+    Then transaction commits
+    Given session opens transaction of type: write
+    Then typeql insert; throws exception
+      """
+      insert $x isa child, has email "abc@gmail.com", has ref 1;
+      """
+
+
+  Scenario: overridden uniqueness is respected
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+
+    Given typeql define
+      """
+      define
+      email-outlook sub email, value string;
+      child sub person, owns email-outlook as email;
+      """
+    Given transaction commits
+
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert $x isa child, has email-outlook "abc@outlook.com", has email-outloop "xyz@outlook.com", has ref 0;
+      """
+    Then transaction commits
+    Given session opens transaction of type: write
+    Then typeql insert; throws exception
+      """
+      insert $x isa child, has email-outloko "abc@outlook.com", has ref 1;
+      """
+
+
+  Scenario: instances of an inherited unique attribute don't have to be unique among instances of the type and its subtypes
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      child sub person;
+      adult sub person;
+      """
+    Given transaction commits
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert
+      $x isa child, has email "abc@gmail.com", has email "xyz@gmail.com", has ref 0;
+      $y isa adult, has email "abc@gmail.com", has email "xyz@gmail.com", has ref 1;
+      """
+    Then transaction commits
 
 
   ###########################

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -1490,24 +1490,24 @@ Parker";
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When session opens transaction of type: write
     When get answers of typeql match
       """
-      match $x isa person, has email "abc@gmail.com";;
+      match $x isa person, has email "abc@gmail.com";
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
     When typeql insert
       """
-      insert $x isa person, has ref 1, has email "abc@gmail.com", has email "xyz@gmail.com";
+      insert $x isa person, has ref 1, has email "mnp@gmail.com", has email "xyz@gmail.com";
       """
     Then transaction commits
 
     When session opens transaction of type: read
     When get answers of typeql match
       """
-      match $x isa person, has email "abc@gmail.com", has email "xyz@gmail.com";
+      match $x isa person, has email "mnp@gmail.com", has email "xyz@gmail.com";
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1524,14 +1524,13 @@ Parker";
     Given session opens transaction of type: write
     Given typeql insert
       """
-      $x isa person, has ref 0, has email "abc@gmail.com";
+      insert $x isa person, has ref 0, has email "abc@gmail.com";
       """
     Then transaction commits
     Given session opens transaction of type: write
     Then typeql insert; throws exception
       """
-      insert
-      $y isa person, has ref 1, has email "abc@gmail.com";
+      insert $y isa person, has ref 1, has email "abc@gmail.com";
       """
 
 
@@ -1568,16 +1567,19 @@ Parker";
     Given typeql define
       """
       define
+      person sub entity, abstract;
+      email sub attribute, value string, abstract;
       email-outlook sub email, value string;
       child sub person, owns email-outlook as email;
       """
     Given transaction commits
+    Given connection close all sessions
 
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
-      insert $x isa child, has email-outlook "abc@outlook.com", has email-outloop "xyz@outlook.com", has ref 0;
+      insert $x isa child, has email-outlook "abc@outlook.com", has email-outlook "xyz@outlook.com", has ref 0;
       """
     Then transaction commits
     Given session opens transaction of type: write

--- a/typeql/language/match.feature
+++ b/typeql/language/match.feature
@@ -329,10 +329,11 @@ Feature: TypeQL Match Query
       match person owns $x;
       """
     Then uniquely identify answer concepts
-      | x          |
-      | label:name |
-      | label:age  |
-      | label:ref  |
+      | x           |
+      | label:name  |
+      | label:email |
+      | label:age   |
+      | label:ref   |
 
 
   Scenario: directly declared 'owns' annotations are queryable
@@ -340,28 +341,34 @@ Feature: TypeQL Match Query
       """
       match $x owns ref @key;
       """
-    Then unique identify answer concepts
-      | x            |
-      | label:person |
+    Then uniquely identify answer concepts
+      | x                |
+      | label:person     |
+      | label:company    |
+      | label:friendship |
+      | label:employment |
     When get answers of typeql match
       """
       match $x owns $a @key;
       """
-    Then unique identify answer concepts
-      | x            | a            |
-      | label:person | label:ref    |
+    Then uniquely identify answer concepts
+      | x                | a            |
+      | label:person     | label:ref    |
+      | label:company    | label:ref    |
+      | label:friendship | label:ref    |
+      | label:employment | label:ref    |
     When get answers of typeql match
       """
       match $x owns email @unique;
       """
-    Then unique identify answer concepts
+    Then uniquely identify answer concepts
       | x            |
       | label:person |
     When get answers of typeql match
       """
       match $x owns $a @unique;
       """
-    Then unique identify answer concepts
+    Then uniquely identify answer concepts
       | x            | a            |
       | label:person | label:email  |
 
@@ -377,23 +384,29 @@ Feature: TypeQL Match Query
       """
       match $x owns ref @key;
       """
-    Then unique identify answer concepts
-      | x            |
-      | label:person |
-      | label:child  |
+    Then uniquely identify answer concepts
+      | x                |
+      | label:person     |
+      | label:child      |
+      | label:company    |
+      | label:friendship |
+      | label:employment |
     When get answers of typeql match
       """
       match $x owns $a @key;
       """
-    Then unique identify answer concepts
-      | x            | a            |
-      | label:person | label:ref    |
-      | label:child  | label:ref    |
+    Then uniquely identify answer concepts
+      | x                | a            |
+      | label:person     | label:ref    |
+      | label:child      | label:ref    |
+      | label:company    | label:ref    |
+      | label:friendship | label:ref    |
+      | label:employment | label:ref    |
     When get answers of typeql match
       """
       match $x owns email @unique;
       """
-    Then unique identify answer concepts
+    Then uniquely identify answer concepts
       | x            |
       | label:person |
       | label:child  |
@@ -401,7 +414,7 @@ Feature: TypeQL Match Query
       """
       match $x owns $a @unique;
       """
-    Then unique identify answer concepts
+    Then uniquely identify answer concepts
       | x            | a            |
       | label:person | label:email  |
       | label:child  | label:email  |

--- a/typeql/language/match.feature
+++ b/typeql/language/match.feature
@@ -35,7 +35,8 @@ Feature: TypeQL Match Query
         plays employment:employee,
         owns name,
         owns age,
-        owns ref @key;
+        owns ref @key,
+        owns email @unique;
       company sub entity,
         plays employment:employer,
         owns name,
@@ -50,6 +51,7 @@ Feature: TypeQL Match Query
       name sub attribute, value string;
       age sub attribute, value long;
       ref sub attribute, value long;
+      email sub attribute, value string;
       """
     Given transaction commits
 
@@ -331,6 +333,78 @@ Feature: TypeQL Match Query
       | label:name |
       | label:age  |
       | label:ref  |
+
+
+  Scenario: directly declared 'owns' annotations are queryable
+    When get answers of typeql match
+      """
+      match $x owns ref @key;
+      """
+    Then unique identify answer concepts
+      | x            |
+      | label:person |
+    When get answers of typeql match
+      """
+      match $x owns $a @key;
+      """
+    Then unique identify answer concepts
+      | x            | a            |
+      | label:person | label:ref    |
+    When get answers of typeql match
+      """
+      match $x owns email @unique;
+      """
+    Then unique identify answer concepts
+      | x            |
+      | label:person |
+    When get answers of typeql match
+      """
+      match $x owns $a @unique;
+      """
+    Then unique identify answer concepts
+      | x            | a            |
+      | label:person | label:email  |
+
+
+  Scenario: inherited 'owns' annotations are queryable
+    Given typeql define
+      """
+      define child sub person;
+      """
+    Given transaction commits
+    Given session opens transaction of type: write
+    When get answers of typeql match
+      """
+      match $x owns ref @key;
+      """
+    Then unique identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+    When get answers of typeql match
+      """
+      match $x owns $a @key;
+      """
+    Then unique identify answer concepts
+      | x            | a            |
+      | label:person | label:ref    |
+      | label:child  | label:ref    |
+    When get answers of typeql match
+      """
+      match $x owns email @unique;
+      """
+    Then unique identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+    When get answers of typeql match
+      """
+      match $x owns $a @unique;
+      """
+    Then unique identify answer concepts
+      | x            | a            |
+      | label:person | label:email  |
+      | label:child  | label:email  |
 
 
   Scenario: 'owns' can be used to retrieve all instances of types that can own a given attribute type


### PR DESCRIPTION
## What is the goal of this PR?

Introduce extensive tests for unique constraints on attributes, generalised behaviours of annotations, and refactored the Concept API scenarios to allow for generalised annotations.

## What are the changes implemented in this PR?

Scenarios to specify:

1. `unique` constraint enforces an attribute is owned by at most one instance.  
2. annotations are inherited not re-declarable. However, they are specialisable (such as unique -> key) in certain valid combinations, and rejected otherwise

We verify that the define/undefine/insert/match paths to do with annotations behave as expected.

We extensively refactor the syntax of the Concept API to specify annotations in a generalised style, instead of treating `key` specially.
