### PR TITLE
Types referenced in rules cannot be undefined

### DIFF
--- a/typeql/language/undefine.feature
+++ b/typeql/language/undefine.feature
@@ -1362,7 +1362,57 @@ Feature: TypeQL Undefine Query
       | n                 |
       | value:name:Samuel |
 
-  Scenario: You cannot undefine a type if it is used in any disjunction of a rule
+  Scenario: You cannot undefine a type if it is used in a rule
+    Given typeql define
+    """
+    define
+
+    type-to-undefine sub entity, owns name;
+
+    rule rule-referencing-type-to-undefine:
+    when {
+      $x isa type-to-undefine;
+    } then {
+      $x has name "dummy";
+    };
+    """
+    Given transaction commits
+
+    Given session opens transaction of type: write
+
+    Given typeql undefine; throws exception
+    """
+    undefine
+      type-to-undefine sub entity;
+    """
+
+  Scenario: You cannot undefine a type if it is used in a negation in a rule
+    Given typeql define
+    """
+    define
+    rel sub relation, relates rol;
+    other-type sub entity, owns name, plays rel:rol;
+    type-to-undefine sub entity, owns name, plays rel:rol;
+
+    rule rule-referencing-type-to-undefine:
+    when {
+      $x isa other-type;
+      not { ($x, $y) isa relation; $y isa type-to-undefine; };
+    } then {
+      $x has name "dummy";
+    };
+    """
+    Given transaction commits
+
+    Given session opens transaction of type: write
+
+    Given typeql undefine; throws exception
+    """
+    undefine
+      type-to-undefine sub entity;
+    """
+
+  Scenario: You cannot undefine a type if it is used in any disjunction in a rule
     Given typeql define
     """
     define

--- a/typeql/language/undefine.feature
+++ b/typeql/language/undefine.feature
@@ -1362,6 +1362,31 @@ Feature: TypeQL Undefine Query
       | n                 |
       | value:name:Samuel |
 
+  Scenario: You cannot undefine a type if it is used in any disjunction of a rule
+    Given typeql define
+    """
+    define
+
+    type-to-undefine sub entity, owns name;
+
+    rule rule-referencing-type-to-undefine:
+    when {
+      $x has name $y;
+      { $x isa person; } or { $x isa type-to-undefine; };
+    } then {
+      $x has name "dummy";
+    };
+    """
+    Given transaction commits
+
+    Given session opens transaction of type: write
+
+    Given typeql undefine; throws exception
+    """
+    undefine
+      type-to-undefine sub entity;
+    """
+
 
   ############
   # ABSTRACT #

--- a/typeql/language/undefine.feature
+++ b/typeql/language/undefine.feature
@@ -1437,6 +1437,29 @@ Feature: TypeQL Undefine Query
       type-to-undefine sub entity;
     """
 
+  Scenario: You cannot undefine a type if it is used in the then of a rule
+    Given typeql define
+    """
+    define
+    name-to-undefine sub attribute, value string;
+    some-type sub entity, owns name-to-undefine;
+
+    rule rule-referencing-type-to-undefine:
+    when {
+      $x isa some-type;
+    } then {
+      $x has name-to-undefine "dummy";
+    };
+    """
+    Given transaction commits
+
+    Given session opens transaction of type: write
+
+    Given typeql undefine; throws exception
+    """
+    undefine
+      name-to-undefine sub entity;
+    """
 
   ############
   # ABSTRACT #


### PR DESCRIPTION
## What is the goal of this PR?
Add a test to ensure we cannot undefined types which are referenced in some rule.

## What are the changes implemented in this PR?
* Adds a scenario to `undefine.feature` which attempts to undefined a type which is referenced in the `then` of a rule
* Adds a scenario to `undefine.feature` which attempts to undefined a type which is referenced in the `when` of a rule
  * if the when is a conjunction
  * in a branch, if the when is a disjunction 
  * in the negation in the when of a rule