### PR TITLE
Ensure exception is thrown when redefining attribute with a  different value type

### DIFF
--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1552,6 +1552,18 @@ Feature: TypeQL Define Query
       define name value long;
       """
 
+    When session opens transaction of type: write
+    Then typeql define; throws exception
+      """
+      define name sub attribute, value long;
+      """
+
+    When session opens transaction of type: write
+    When typeql define
+      """
+      define name sub attribute, value string;
+      """
+    Then transaction commits
 
   Scenario: an attribute ownership can be converted to a key ownership
     When typeql define

--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1468,6 +1468,20 @@ Feature: TypeQL Define Query
       | label:employment |
 
 
+  Scenario: Redefining an attribute type succeeds if and only if the value type remains unchanged
+    Then typeql define; throws exception
+      """
+      define name sub attribute, value long;
+      """
+
+    When session opens transaction of type: write
+    When typeql define
+      """
+      define name sub attribute, value string;
+      """
+    Then transaction commits
+
+
   Scenario: a regex constraint can be added to an existing attribute type if all its instances satisfy it
     Given connection close all sessions
     Given connection open data session for database: typedb
@@ -1557,13 +1571,6 @@ Feature: TypeQL Define Query
       """
       define name sub attribute, value long;
       """
-
-    When session opens transaction of type: write
-    When typeql define
-      """
-      define name sub attribute, value string;
-      """
-    Then transaction commits
 
   Scenario: an attribute ownership can be converted to a key ownership
     When typeql define


### PR DESCRIPTION
## What is the goal of this PR?
Verify exception is thrown when an attempt is made to modify the  value type of an attribute with a `sub` constraint.
  
## What are the changes implemented in this PR?
* Add test to ensure exception is thrown when a `define` query attempts to redefine an attribute value type to a different one with a sub attribute, as detailed in [typedb/#6789](https://github.com/vaticle/typedb/issues/6789) 