### PR TITLE
Refactor connection open syntax and remove usage of 'And'

### DIFF
--- a/concept/serialization/json.feature
+++ b/concept/serialization/json.feature
@@ -19,8 +19,8 @@
 Feature: Concept Serialization
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -19,8 +19,8 @@
 Feature: Concept Attribute
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -19,8 +19,8 @@
 Feature: Concept Entity
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -19,8 +19,8 @@
 Feature: Concept Relation
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -19,8 +19,8 @@
 Feature: Concept Attribute Type
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -19,8 +19,8 @@
 Feature: Concept Entity Type
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -19,8 +19,8 @@
 Feature: Concept Relation Type and Role Type
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/concept/type/thingtype.feature
+++ b/concept/type/thingtype.feature
@@ -19,8 +19,8 @@
 Feature: Concept Thing Type
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -19,8 +19,8 @@
 Feature: Connection Database
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
 

--- a/connection/session.feature
+++ b/connection/session.feature
@@ -19,8 +19,8 @@
 Feature: Connection Session
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
 

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -19,8 +19,8 @@
 Feature: Connection Transaction
 
   Background:
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
 

--- a/connection/user.feature
+++ b/connection/user.feature
@@ -19,21 +19,21 @@
 Feature: Connection Users
 
   Scenario: users can be created and deleted
-    When typedb starts
-    And user connect: admin, password
+    Given typedb starts
+    Given connection opens with authentication: admin, password
     Then users contains: admin
-    And users not contains: user
+    Then users not contains: user
     When users create: user, password
-    And users create: user2, password2
-    And users contains: user
-    And users contains: user2
-    And users password set: user, new-password
-    And users delete: user2
-    And user disconnect
-    And user connect: user, new-password
-    And user disconnect
-    And user connect: admin, password
-    And users delete: user
+    When users create: user2, password2
+    When users contains: user
+    When users contains: user2
+    When users password set: user, new-password
+    When users delete: user2
+    Then connection closes
+    Given connection opens with authentication: user, new-password
+    Then connection closes
+    Given connection opens with authentication: admin, password
+    Given users delete: user
     Then users not contains: user
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
@@ -41,95 +41,95 @@ Feature: Connection Users
     Given typedb has configuration
       |server.authentication.password-policy.complexity.min-length|5|
       |server.authentication.password-policy.complexity.enable|true|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And users create: user2, passw
-    And users create: user3, pass; throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then users create: user2, passw
+    Then users create: user3, pass; throws exception
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords must comply with the minimum number of lowercase characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.min-lowercase|2|
       |server.authentication.password-policy.complexity.enable|true|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And users create: user2, paSSWORD
-    And users create: user3, PASSWORD; throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then users create: user2, paSSWORD
+    Then users create: user3, PASSWORD; throws exception
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords must comply with the minimum number of uppercase characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.min-uppercase|2|
       |server.authentication.password-policy.complexity.enable|true|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, PASSWORD
-    And users create: user2, PAssword
-    And users create: user3, password; throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, PASSWORD
+    Then users create: user2, PAssword
+    Then users create: user3, password; throws exception
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords must comply with the minimum number of numeric characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.min-numerics|2|
       |server.authentication.password-policy.complexity.enable|true|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, PASSWORD789
-    And users create: user2, PASSWORD78
-    And users create: user3, PASSWORD7; throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, PASSWORD789
+    Then users create: user2, PASSWORD78
+    Then users create: user3, PASSWORD7; throws exception
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords must comply with the minimum number of special characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.min-special-chars|2|
       |server.authentication.password-policy.complexity.enable|true|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, PASSWORD!@£
-    And users create: user2, PASSWORD&(
-    And users create: user3, PASSWORD); throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, PASSWORD!@£
+    Then users create: user2, PASSWORD&(
+    Then users create: user3, PASSWORD); throws exception
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords must comply with the minimum number of different characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.min-different-chars|4|
       |server.authentication.password-policy.complexity.enable|true|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And user disconnect
-    And user connect: user, password
-    And user password update: password, new-password
-    And user disconnect
-    And user connect: user, new-password
-    And user password update: new-password, bad-password; throws exception
-    And user password update: new-password, even-newer-password
-    And user disconnect
-    And user connect: user, even-newer-password
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then connection closes
+    Given connection opens with authentication: user, password
+    Then user password update: password, new-password
+    Then connection closes
+    Given connection opens with authentication: user, new-password
+    Then user password update: new-password, bad-password; throws exception
+    Then user password update: new-password, even-newer-password
+    Then connection closes
+    Given connection opens with authentication: user, even-newer-password
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords must be unique for a certain history size
     Given typedb has configuration
       |server.authentication.password-policy.unique-history-size|2|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And user disconnect
-    And user connect: user, password
-    And user password update: password, password; throws exception
-    And user password update: password, new-password
-    And user disconnect
-    And user connect: user, new-password
-    And user password update: new-password, password; throws exception
-    And user disconnect
-    And user connect: user, new-password
-    And user password update: new-password, newer-password
-    And user disconnect
-    And user connect: user, newer-password
-    And user password update: newer-password, newest-password
-    And user connect: user, newest-password
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then connection closes
+    Given connection opens with authentication: user, password
+    Then user password update: password, password; throws exception
+    Then user password update: password, new-password
+    Then connection closes
+    Given connection opens with authentication: user, new-password
+    Then user password update: new-password, password; throws exception
+    Then connection closes
+    Given connection opens with authentication: user, new-password
+    Then user password update: new-password, newer-password
+    Then connection closes
+    Given connection opens with authentication: user, newer-password
+    Then user password update: newer-password, newest-password
+    Given connection opens with authentication: user, newest-password
     And user password update: newest-password, password
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
@@ -138,12 +138,12 @@ Feature: Connection Users
       |server.authentication.password-policy.expiration.enable|true|
       |server.authentication.password-policy.expiration.min-duration|0s|
       |server.authentication.password-policy.expiration.max-duration|5d|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And user disconnect
-    And user connect: user, password
-    And user expiry-seconds
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then connection closes
+    Given connection opens with authentication: user, password
+    Then user expiry-seconds
 
   @ignore-typedb-client-python @ignore-typedb-client-nodejs
   Scenario: user passwords expire
@@ -151,24 +151,24 @@ Feature: Connection Users
       |server.authentication.password-policy.expiration.enable|true|
       |server.authentication.password-policy.expiration.min-duration|0s|
       |server.authentication.password-policy.expiration.max-duration|5s|
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And user disconnect
-    And wait 5 seconds
-    And user connect: user, password; throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then connection closes
+    Then wait 5 seconds
+    Given connection opens with authentication: user, password; throws exception
 
   Scenario: non-admin user cannot perform permissioned actions
-    When typedb starts
-    And user connect: admin, password
-    And users create: user, password
-    And users create: user2, password2
-    And user disconnect
-    And user connect: user, password
-    And users get all; throws exception
-    And users get user: admin; throws exception
-    And users create: user3, password; throws exception
-    And users contains: admin; throws exception
-    And users delete: admin; throws exception
-    And users delete: user2; throws exception
-    And users password set: user2, new-password; throws exception
+    Given typedb starts
+    Given connection opens with authentication: admin, password
+    Then users create: user, password
+    Then users create: user2, password2
+    Then connection closes
+    Given connection opens with authentication: user, password
+    Then users get all; throws exception
+    Then users get user: admin; throws exception
+    Then users create: user3, password; throws exception
+    Then users contains: admin; throws exception
+    Then users delete: admin; throws exception
+    Then users delete: user2; throws exception
+    Then users password set: user2, new-password; throws exception

--- a/typeql/explanation/language.feature
+++ b/typeql/explanation/language.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Reasoning Explanation
 
   Background: Initialise a session and transaction for each scenario
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection open schema session for database: test_explanation
     Given transaction is initialised

--- a/typeql/explanation/reasoner.feature
+++ b/typeql/explanation/reasoner.feature
@@ -21,8 +21,8 @@ Feature: TypeQL Reasoning Explanation
   Only scenarios where there is only one possible resolution path can be tested in this way
 
   Background: Initialise a session and transaction for each scenario
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection open schema session for database: test_explanation
     Given transaction is initialised

--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Define Query
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/delete.feature
+++ b/typeql/language/delete.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Delete Query
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/get.feature
+++ b/typeql/language/get.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Get Clause
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Insert Query
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/match.feature
+++ b/typeql/language/match.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Match Query
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/rule-validation.feature
+++ b/typeql/language/rule-validation.feature
@@ -18,8 +18,8 @@
 Feature: TypeQL Rule Validation
 
   Background: Initialise a session and transaction for each scenario
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/undefine.feature
+++ b/typeql/language/undefine.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Undefine Query
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/language/update.feature
+++ b/typeql/language/update.feature
@@ -19,8 +19,8 @@
 Feature: TypeQL Update Query
 
   Background: Open connection and create a simple extensible schema
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given connection has been opened
     Given connection does not have any database
     Given connection create database: typedb

--- a/typeql/reasoner/attribute-attachment.feature
+++ b/typeql/reasoner/attribute-attachment.feature
@@ -19,8 +19,8 @@
 Feature: Attribute Attachment Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/compound-queries.feature
+++ b/typeql/reasoner/compound-queries.feature
@@ -19,8 +19,8 @@
 Feature: Compound Query Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/concept-inequality.feature
+++ b/typeql/reasoner/concept-inequality.feature
@@ -19,8 +19,8 @@
 Feature: Concept Inequality Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/negation.feature
+++ b/typeql/reasoner/negation.feature
@@ -19,8 +19,8 @@
 Feature: Negation Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/recursion.feature
+++ b/typeql/reasoner/recursion.feature
@@ -22,8 +22,8 @@ Feature: Recursion Resolution
   This test feature verifies that so-called recursive inference works as intended.
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/relation-inference.feature
+++ b/typeql/reasoner/relation-inference.feature
@@ -19,8 +19,8 @@
 Feature: Relation Inference Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/rule-interaction.feature
+++ b/typeql/reasoner/rule-interaction.feature
@@ -19,8 +19,8 @@
 Feature: Rule Interaction Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/schema-queries.feature
+++ b/typeql/reasoner/schema-queries.feature
@@ -19,8 +19,8 @@
 Feature: Schema Query Resolution (Variable Types)
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/type-hierarchy.feature
+++ b/typeql/reasoner/type-hierarchy.feature
@@ -19,8 +19,8 @@
 Feature: Type Hierarchy Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
 
   Scenario: subtypes trigger rules based on their parents; parent types don't trigger rules based on their children
     Given reasoning schema

--- a/typeql/reasoner/value-predicate.feature
+++ b/typeql/reasoner/value-predicate.feature
@@ -19,8 +19,8 @@
 Feature: Value Predicate Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define

--- a/typeql/reasoner/variable-roles.feature
+++ b/typeql/reasoner/variable-roles.feature
@@ -20,8 +20,8 @@
 Feature: Variable Role Resolution
 
   Background: Set up database
-    When typedb starts
-    And open connection
+    Given typedb starts
+    Given connection opens without authentication
     Given reasoning schema
       """
       define


### PR DESCRIPTION
## What is the goal of this PR?

We make the connection steps more explicit and consistent. We also remove usages of `And` that were introduced but in #242 but are inconsistent with the existing style.

## What are the changes implemented in this PR?

* Rename `open connection` (which is ambiguous of an assertion or action) to `connection opens without authentication`
* Rename `user connect:` -> `connection opens with authentication:` to be consistent with the other connection open step
* Rename `user disconnect` to `connection closes` since it works for any connections/clients, not just user-authenticated ones
