### PR TITLE
Tests insertion and retrieval of datetime attributes are timezone-invariant

### DIFF
--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -173,6 +173,22 @@ Feature: Concept Attribute
     When $x = attribute(birth-date) as(datetime) get: 1990-01-01 11:22:33
     Then attribute(birth-date) get instances contain: $x
 
+  Scenario: Attribute with value type datetime can be inserted in one timezone and retrieved in another timezone with no change in the value
+    When set time-zone is: Asia/Calcutta
+    When $x = attribute(birth-date) as(datetime) put: 2001-08-23 08:30:00
+    Then attribute $x is null: false
+    Then attribute $x has type: birth-date
+    Then attribute $x has value type: datetime
+    Then attribute $x has datetime value: 2001-08-23 08:30:00
+    When transaction commits
+    When session opens transaction of type: read
+    When set time-zone is: America/Chicago
+    When $x = attribute(birth-date) as(datetime) get: 2001-08-23 08:30:00
+    Then attribute $x is null: false
+    Then attribute $x has type: birth-date
+    Then attribute $x has value type: datetime
+    Then attribute $x has datetime value: 2001-08-23 08:30:00
+
   Scenario: Attribute with value type boolean can be deleted
     When $x = attribute(is-alive) as(boolean) put: true
     When delete attribute: $x
@@ -308,19 +324,6 @@ Feature: Concept Attribute
 
   Scenario: Attribute with value type double can be owned
 
-  Scenario: Attribute with value type datetime can be inserted in one timezone and queried in another timezone with no change in the value
-    When set time-zone is: Asia/Calcutta
-    When $x = attribute(birth-date) as(datetime) put: 2001-08-23 08:30:00
-    Then attribute $x is null: false
-    Then attribute $x has type: birth-date
-    Then attribute $x has value type: datetime
-    Then attribute $x has datetime value: 2001-08-23 08:30:00
-    When transaction commits
-    When session opens transaction of type: read
-    When set time-zone is: America/Chicago
-    When $x = attribute(birth-date) as(datetime) get: 2001-08-23 08:30:00
-    Then attribute $x is null: false
-    Then attribute $x has type: birth-date
-    Then attribute $x has value type: datetime
-    Then attribute $x has datetime value: 2001-08-23 08:30:00
+  Scenario: Attribute with value type string can be owned
 
+  Scenario: Attribute with value type datetime can be owned

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -45,6 +45,7 @@ Feature: Concept Attribute
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
+    Given set time-zone is: Europe/London
 
   Scenario: Attribute with value type boolean can be created
     When $x = attribute(is-alive) as(boolean) put: true

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -308,6 +308,19 @@ Feature: Concept Attribute
 
   Scenario: Attribute with value type double can be owned
 
-  Scenario: Attribute with value type string can be owned
+  Scenario: Attribute with value type datetime can be inserted in one timezone and queried in another timezone with no change in the value
+    When set time-zone is: Asia/Calcutta
+    When $x = attribute(birth-date) as(datetime) put: 2001-08-23 08:30:00
+    Then attribute $x is null: false
+    Then attribute $x has type: birth-date
+    Then attribute $x has value type: datetime
+    Then attribute $x has datetime value: 2001-08-23 08:30:00
+    When transaction commits
+    When session opens transaction of type: read
+    When set time-zone is: America/Chicago
+    When $x = attribute(birth-date) as(datetime) get: 2001-08-23 08:30:00
+    Then attribute $x is null: false
+    Then attribute $x has type: birth-date
+    Then attribute $x has value type: datetime
+    Then attribute $x has datetime value: 2001-08-23 08:30:00
 
-  Scenario: Attribute with value type datetime can be owned

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -174,7 +174,7 @@ Feature: Concept Attribute
     When $x = attribute(birth-date) as(datetime) get: 1990-01-01 11:22:33
     Then attribute(birth-date) get instances contain: $x
 
-  Scenario: Attribute with value type datetime can be inserted in one timezone and retrieved in another timezone with no change in the value
+  Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
     When set time-zone is: Asia/Calcutta
     When $x = attribute(birth-date) as(datetime) put: 2001-08-23 08:30:00
     Then attribute $x is null: false

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -2781,7 +2781,8 @@ Parker";
     Given session opens transaction of type: write
     Given typeql define
     """
-    define test_date sub attribute, value datetime;
+    define
+    test_date sub attribute, value datetime;
     """
     Given transaction commits
 

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -238,6 +238,8 @@ Feature: TypeQL Insert Query
       insert $x isa thing;
       """
 
+
+
   #######################
   # ATTRIBUTE OWNERSHIP #
   #######################
@@ -2770,6 +2772,7 @@ Parker";
       $x isa bird;
       $x iid V123;
       """
+
 
   Scenario: datetime object can be inserted and queried correctly (and time-zone-naively) regardless of OS timezone
     Given set time-zone is: Asia/Calcutta

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -1049,38 +1049,6 @@ Parker";
   # ATTRIBUTE INSERTION #
   #######################
 
-  Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
-    Given set time-zone is: Asia/Calcutta
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-    """
-    define
-    test_date sub attribute, value datetime;
-    """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    When session opens transaction of type: write
-    Then typeql insert
-      """
-      insert
-      $time_date 2023-05-01T00:00:00 isa test_date;
-      """
-
-    Given set time-zone is: America/Chicago
-    Given transaction commits
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa test_date;
-      """
-    Then uniquely identify answer concepts
-      | x                                  |
-      | attr:test_date:2023-05-01T00:00:00 |
-
   Scenario Outline: inserting an attribute of type '<type>' creates an instance of it
     Given connection close all sessions
     Given connection open schema session for database: typedb
@@ -1191,6 +1159,37 @@ Parker";
         $a "10.maybe";
       """
 
+  Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
+    Given set time-zone is: Asia/Calcutta
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+    """
+    define
+    test_date sub attribute, value datetime;
+    """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    When session opens transaction of type: write
+    Then typeql insert
+      """
+      insert
+      $time_date 2023-05-01T00:00:00 isa test_date;
+      """
+
+    Given set time-zone is: America/Chicago
+    Given transaction commits
+    Given session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x isa test_date;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | attr:test_date:2023-05-01T00:00:00 |
 
   Scenario: inserting two attributes with the same type and value creates only one concept
     When typeql insert

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -2794,6 +2794,7 @@ Parker";
       insert
       $time_date 2023-05-01T00:00:00 isa test_date;
       """
+
     Given set time-zone is: America/Chicago
     Given transaction commits
     Given session opens transaction of type: read

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -268,6 +268,38 @@ Feature: TypeQL Insert Query
       | attr:age:25           |
       | attr:ref:0            |
 
+  Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
+    Given set time-zone is: Asia/Calcutta
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+    """
+    define
+    test_date sub attribute, value datetime;
+    """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    When session opens transaction of type: write
+    Then typeql insert
+      """
+      insert
+      $time_date 2023-05-01T00:00:00 isa test_date;
+      """
+
+    Given set time-zone is: America/Chicago
+    Given transaction commits
+    Given session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x isa test_date;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | attr:test_date:2023-05-01T00:00:00 |
+
   Scenario: when inserting a new thing that owns new attributes via a value variable, both the thing and the attributes get created
     Given get answers of typeql match
       """
@@ -2773,35 +2805,3 @@ Parker";
       $x iid V123;
       """
 
-
-  Scenario: datetime object can be inserted and queried correctly (and time-zone-naively) regardless of OS timezone
-    Given set time-zone is: Asia/Calcutta
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-    """
-    define
-    test_date sub attribute, value datetime;
-    """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    When session opens transaction of type: write
-    Then typeql insert
-      """
-      insert
-      $time_date 2023-05-01T00:00:00 isa test_date;
-      """
-
-    Given set time-zone is: America/Chicago
-    Given transaction commits
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa test_date;
-      """
-    Then uniquely identify answer concepts
-      | x                                  |
-      | attr:test_date:2023-05-01T00:00:00 |

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -65,7 +65,7 @@ Feature: TypeQL Insert Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-
+    Given set time-zone is: Europe/London
 
   ####################
   # INSERTING THINGS #

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -238,8 +238,6 @@ Feature: TypeQL Insert Query
       insert $x isa thing;
       """
 
-
-
   #######################
   # ATTRIBUTE OWNERSHIP #
   #######################
@@ -2772,3 +2770,33 @@ Parker";
       $x isa bird;
       $x iid V123;
       """
+
+  Scenario: datetime object can be inserted and queried correctly (and time-zone-naively) regardless of OS timezone
+    Given set time-zone is: Asia/Calcutta
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+    """
+    define test_date sub attribute, value datetime;
+    """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    When session opens transaction of type: write
+    Then typeql insert
+      """
+      insert
+      $time_date 2023-05-01T00:00:00 isa test_date;
+      """
+    Given set time-zone is: America/Chicago
+    Given transaction commits
+    Given session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x isa test_date;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | attr:test_date:2023-05-01 00:00:00 |

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -2803,4 +2803,4 @@ Parker";
       """
     Then uniquely identify answer concepts
       | x                                  |
-      | attr:test_date:2023-05-01 00:00:00 |
+      | attr:test_date:2023-05-01T00:00:00 |

--- a/typeql/language/insert.feature
+++ b/typeql/language/insert.feature
@@ -268,38 +268,6 @@ Feature: TypeQL Insert Query
       | attr:age:25           |
       | attr:ref:0            |
 
-  Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
-    Given set time-zone is: Asia/Calcutta
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-    """
-    define
-    test_date sub attribute, value datetime;
-    """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    When session opens transaction of type: write
-    Then typeql insert
-      """
-      insert
-      $time_date 2023-05-01T00:00:00 isa test_date;
-      """
-
-    Given set time-zone is: America/Chicago
-    Given transaction commits
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa test_date;
-      """
-    Then uniquely identify answer concepts
-      | x                                  |
-      | attr:test_date:2023-05-01T00:00:00 |
-
   Scenario: when inserting a new thing that owns new attributes via a value variable, both the thing and the attributes get created
     Given get answers of typeql match
       """
@@ -1080,6 +1048,38 @@ Parker";
   #######################
   # ATTRIBUTE INSERTION #
   #######################
+
+  Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
+    Given set time-zone is: Asia/Calcutta
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+    """
+    define
+    test_date sub attribute, value datetime;
+    """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    When session opens transaction of type: write
+    Then typeql insert
+      """
+      insert
+      $time_date 2023-05-01T00:00:00 isa test_date;
+      """
+
+    Given set time-zone is: America/Chicago
+    Given transaction commits
+    Given session opens transaction of type: read
+    When get answers of typeql match
+      """
+      match $x isa test_date;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | attr:test_date:2023-05-01T00:00:00 |
 
   Scenario Outline: inserting an attribute of type '<type>' creates an instance of it
     Given connection close all sessions


### PR DESCRIPTION
## What is the goal of this PR?


TypeQL and ConceptAPI BDD tests for verifying that insertion and retrieval of datetime attributes are timezone-invariant.

## What are the changes implemented in this PR?

- Added a test in `attribute.feature` in `concept` and `insert.feature` in `typeql` folders which changes timezone between insertion and read query of a datetime attribute.
