### PR TITLE
Re-enable and add tests for database management in typedb-cluster

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -152,7 +152,5 @@ Feature: Connection Database
       """
 
 
-  # TODO: re-enable in Cluster once fully fault-tolerant database deletion is implemented
-  @ignore-typedb-cluster
   Scenario: delete a nonexistent database throws an error
     When connection delete database; throws exception: typedb

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -128,6 +128,15 @@ Feature: Connection Database
     Then connection does not have any database
 
 
+  Scenario: create delete and recreate a database
+    When connection create database: alice
+    Then connection has database: alice
+    When connection delete database: alice
+    Then connection does not have database: alice
+    When connection create database: alice
+    Then connection has database: alice
+
+
   # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see client-java#225)
   @ignore
   Scenario: delete a database causes open sessions to fail


### PR DESCRIPTION
## What is the goal of this PR?
Re-enables a behaviour test for typedb-cluster which verifies an exception is thrown when we try to delete a non-existent database. Also adds a test to create, delete and recreate a database


## What are the changes implemented in this PR?
* Unignores scenario `delete a nonexistent database throws an error` in `connection/database.feature`
* Adds a test to create a database, delete it, and create it again. This is interesting in the context of typedb-cluster.