### PR TITLE
Test that overlapping deletes do not fail

### DIFF
--- a/typeql/language/delete.feature
+++ b/typeql/language/delete.feature
@@ -700,6 +700,14 @@ Feature: TypeQL Delete Query
       delete
         $r (friend: $x, friend: $y);
       """
+    Given transaction commits
+    When session opens transaction of type: write
+    When get answers of typeql match
+      """
+      match $r (friend: $x, friend: $y) isa friendship;
+      """
+    Then answer size is: 0
+
     Then typeql delete
       """
       match
@@ -707,7 +715,30 @@ Feature: TypeQL Delete Query
       delete
         $x has $a, has $b;
       """
+    Given transaction commits
+    When session opens transaction of type: write
+    When get answers of typeql match
+      """
+      match $r has email $a, has email $b;
+      """
+    Then answer size is: 0
 
+    Then typeql delete
+      """
+      match
+        $x isa person;
+        $y isa person;
+      delete
+        $x isa person;
+        $y isa person;
+      """
+    Given transaction commits
+    When session opens transaction of type: write
+    When get answers of typeql match
+      """
+      match $x isa person; $y isa person;
+      """
+    Then answer size is: 0
 
   Scenario: when all instances that play roles in a relation are deleted, the relation instance gets cleaned up
     Given get answers of typeql insert


### PR DESCRIPTION
## What is the goal of this PR?

We relax existing delete semantics in https://github.com/vaticle/typedb/pull/6884, by allowing deletes to be idempotent/not fail if deleting a concept or connection that is already removed. We modify existing tests that asserted the opposite behaviour (throw of doing a repeated deletion), and add the other cases of deleting role players or attribute ownership.

## What are the changes implemented in this PR?

* Convert scenario for duplicate deletion throwing to duplicate deletion working
* Add scenario to check that duplicate `has`, `role player` or `isa` deletion is allowed

