### PR TITLE
All role types from abstract relation types are concrete and inheritable

### DIFF
--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -176,7 +176,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(employment) get role(employee) get label: employee
     Then relation(employment) get role(employer) get label: employer
 
-  Scenario: Relation and role types can be set to abstract
+  Scenario: Relation type can be set to abstract while role types remain concrete
     When put relation type: marriage
     When relation(marriage) set relates role: husband
     When relation(marriage) set relates role: wife
@@ -185,8 +185,8 @@ Feature: Concept Relation Type and Role Type
     When relation(parentship) set relates role: parent
     When relation(parentship) set relates role: child
     Then relation(marriage) is abstract: true
-    Then relation(marriage) get role(husband) is abstract: true
-    Then relation(marriage) get role(wife) is abstract: true
+    Then relation(marriage) get role(husband) is abstract: false
+    Then relation(marriage) get role(wife) is abstract: false
     When transaction commits
     When session opens transaction of type: write
     Then relation(parentship) is abstract: false
@@ -195,8 +195,8 @@ Feature: Concept Relation Type and Role Type
     When transaction commits
     When session opens transaction of type: write
     Then relation(marriage) is abstract: true
-    Then relation(marriage) get role(husband) is abstract: true
-    Then relation(marriage) get role(wife) is abstract: true
+    Then relation(marriage) get role(husband) is abstract: false
+    Then relation(marriage) get role(wife) is abstract: false
     When transaction commits
     When session opens transaction of type: write
     Then relation(parentship) is abstract: false
@@ -204,15 +204,15 @@ Feature: Concept Relation Type and Role Type
     Then relation(parentship) get role(child) is abstract: false
     Then relation(parentship) set abstract: true
     Then relation(parentship) is abstract: true
-    Then relation(parentship) get role(parent) is abstract: true
-    Then relation(parentship) get role(child) is abstract: true
+    Then relation(parentship) get role(parent) is abstract: false
+    Then relation(parentship) get role(child) is abstract: false
     When transaction commits
     When session opens transaction of type: read
     Then relation(parentship) is abstract: true
-    Then relation(parentship) get role(parent) is abstract: true
-    Then relation(parentship) get role(child) is abstract: true
+    Then relation(parentship) get role(parent) is abstract: false
+    Then relation(parentship) get role(child) is abstract: false
 
-  Scenario: relation and role types can be set to abstract when a subtype has instances
+  Scenario: relation types can be set to abstract when a subtype has instances
     When put relation type: parentship
     When relation(parentship) set relates role: parent
     When relation(parentship) set relates role: child

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -471,6 +471,24 @@ Feature: Concept Relation Type and Role Type
     Then relation(mothership) get related explicit roles do not contain:
       | parentship:child  |
 
+  Scenario: Roles can be inherited from abstract relation types
+    When put relation type: parentship
+    Then relation(parentship) set abstract: true
+    When relation(parentship) set relates role: parent
+    When relation(parentship) set relates role: child
+    When put relation type: fathership
+    When relation(fathership) set supertype: parentship
+    When transaction commits
+    When session opens transaction of type: read
+    Then relation(fathership) get related roles contain:
+      | parentship:parent |
+      | parentship:child  |
+    Then relation(fathership) get related explicit roles do not contain:
+      | fathership:parent |
+      | fathership:child  |
+    Then relation(fathership) get role(parent) is abstract: false
+    Then relation(fathership) get role(child) is abstract: false
+
   Scenario: Relation types can override inherited related role types
     When put relation type: parentship
     When relation(parentship) set relates role: parent


### PR DESCRIPTION
## What is the goal of this PR?

We update and create scenarios to test that roles are always non-abstract, even when defined from an abstract relation. This allows relation subtypes to inherit roles without having to redeclare them

## What are the changes implemented in this PR?

* Update existing scenario that ensured roles were abstract in synchrony with their source relation - all roles are now concrete
* Create new scenario to test that roles from abstract relations are inherited and concrete.

