### PR TITLE
Add TypeQL Fetch scenarios and refactor Get query steps

### DIFF
--- a/concept/serialization/json.feature
+++ b/concept/serialization/json.feature
@@ -60,7 +60,7 @@ Feature: Concept Serialization
   Scenario: Serialized type contains its label
     When get answers of typeql get
       """
-      match $x type person;
+      match $x type person; get;
       """
     Then JSON serialization of answers matches
       """
@@ -76,7 +76,7 @@ Feature: Concept Serialization
       """
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then JSON serialization of answers matches
       """
@@ -97,7 +97,7 @@ Feature: Concept Serialization
       """
     When get answers of typeql get
       """
-      match $x isa relation;
+      match $x isa relation; get;
       """
     Then JSON serialization of answers matches
       """
@@ -115,7 +115,7 @@ Feature: Concept Serialization
       """
     When get answers of typeql get
       """
-      match $x isa attribute;
+      match $x isa attribute; get;
       """
     Then JSON serialization of answers matches
       """
@@ -133,7 +133,7 @@ Feature: Concept Serialization
       """
     When get answers of typeql get
       """
-      match $x isa date-of-birth;
+      match $x isa date-of-birth; get;
       """
     Then JSON serialization of answers matches
       """
@@ -150,7 +150,7 @@ Feature: Concept Serialization
       """
     When get answers of typeql get
       """
-      match $x isa date-of-birth;
+      match $x isa date-of-birth; get;
       """
     Then JSON serialization of answers matches
       """
@@ -199,7 +199,7 @@ Feature: Concept Serialization
       """
     When get answers of typeql get
       """
-      match $x($r:$y) isa! $t, has ref $z;
+      match $x($r:$y) isa! $t, has ref $z; get;
       """
     Then JSON serialization of answers matches
       """

--- a/concept/serialization/json.feature
+++ b/concept/serialization/json.feature
@@ -175,6 +175,7 @@ Feature: Concept Serialization
         ?d = 543.21;
         ?b = false;
         ?t = 2023-03-21T12:34;
+      get;
       """
     Then JSON serialization of answers matches
       """

--- a/concept/serialization/json.feature
+++ b/concept/serialization/json.feature
@@ -58,7 +58,7 @@ Feature: Concept Serialization
     Given session opens transaction of type: write
 
   Scenario: Serialized type contains its label
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type person;
       """
@@ -74,7 +74,7 @@ Feature: Concept Serialization
       $x isa person, has ref 0;
       $y isa person, has ref 1;
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -95,7 +95,7 @@ Feature: Concept Serialization
       $z (friend: $x) isa friendship, has ref 2;
       $w (employee: $x, employer: $y) isa employment, has ref 3;
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa relation;
       """
@@ -113,7 +113,7 @@ Feature: Concept Serialization
       insert
       $x isa person, has ref 0, has name "Alan";
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa attribute;
       """
@@ -131,7 +131,7 @@ Feature: Concept Serialization
       insert
       $dob 2023-03-21T12:34:56.789 isa date-of-birth;
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa date-of-birth;
       """
@@ -148,7 +148,7 @@ Feature: Concept Serialization
       $b 2023-03-21T12:34 isa date-of-birth;
       $c 2023-03-21 isa date-of-birth;
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa date-of-birth;
       """
@@ -167,7 +167,7 @@ Feature: Concept Serialization
       insert
       $x isa person, has ref 0, has name "Alan";
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         ?s = "Alan";
@@ -197,7 +197,7 @@ Feature: Concept Serialization
       $y isa company, has ref 1;
       $z (employee: $x, employer: $y) isa employment, has ref 2;
       """
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x($r:$y) isa! $t, has ref $z;
       """

--- a/driver/query.feature
+++ b/driver/query.feature
@@ -97,7 +97,7 @@ Feature: TypeDB Driver Queries
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
 
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub entity;
       """
@@ -113,7 +113,7 @@ Feature: TypeDB Driver Queries
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub entity;
       """
@@ -162,7 +162,7 @@ Feature: TypeDB Driver Queries
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -211,7 +211,7 @@ Feature: TypeDB Driver Queries
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -310,7 +310,7 @@ Feature: TypeDB Driver Queries
   Scenario: when a 'get' has unbound variables, an error is thrown
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa person; get $y;
       """
@@ -328,7 +328,7 @@ Feature: TypeDB Driver Queries
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $z isa person, has name $x, has age $y;
@@ -353,7 +353,7 @@ Feature: TypeDB Driver Queries
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa person;
@@ -361,7 +361,7 @@ Feature: TypeDB Driver Queries
         $f isa friendship;
       """
     Then answer size is: 9
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match
         $x isa person;
@@ -370,7 +370,7 @@ Feature: TypeDB Driver Queries
       count;
       """
     Then aggregate value is: 9
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa person;
@@ -378,7 +378,7 @@ Feature: TypeDB Driver Queries
         $f (friend: $x) isa friendship;
       """
     Then answer size is: 6
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match
         $x isa person;
@@ -402,7 +402,7 @@ Feature: TypeDB Driver Queries
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match group
+    When get answers of typeql get group
       """
       match
        $x isa person, has ref $r;
@@ -432,11 +432,11 @@ Feature: TypeDB Driver Queries
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
-    When get answers of typeql match group aggregate
+    When get answers of typeql get group aggregate
       """
       match ($x, $y) isa friendship;
       group $x;
@@ -457,7 +457,7 @@ Feature: TypeDB Driver Queries
     Given connection open data session for database: typedb
 
     Given session opens transaction of type: read
-    Then typeql match; throws exception containing "value variable '?v' is never assigned to"
+    Then typeql get; throws exception containing "value variable '?v' is never assigned to"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -468,7 +468,7 @@ Feature: TypeDB Driver Queries
       """
 
     Given session opens transaction of type: read
-    Then typeql match; throws exception containing "value variable '?v' can only have one assignment in the first scope"
+    Then typeql get; throws exception containing "value variable '?v' can only have one assignment in the first scope"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -482,7 +482,7 @@ Feature: TypeDB Driver Queries
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6.0 + 3.0;
@@ -496,7 +496,7 @@ Feature: TypeDB Driver Queries
       | a                 | b                 | c                  | d                  |
       | value:double: 9.0 | value:double: 3.0 | value:double: 18.0 | value:double: 2.0  |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6 + 3;
@@ -510,7 +510,7 @@ Feature: TypeDB Driver Queries
       | a             | b            | c             | d                  |
       | value:long: 9 | value:long:3 | value:long:18 | value:double: 2.0  |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6.0 + 3;
@@ -524,7 +524,7 @@ Feature: TypeDB Driver Queries
       | a                 | b                 | c                  | d                  |
       | value:double: 9.0 | value:double: 3.0 | value:double: 18.0 | value:double: 2.0  |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6 + 3.0;

--- a/driver/query.feature
+++ b/driver/query.feature
@@ -359,6 +359,7 @@ Feature: TypeDB Driver Queries
         $x isa person;
         $y isa name;
         $f isa friendship;
+      get;
       """
     Then answer size is: 9
     When get answer of typeql get aggregate
@@ -367,6 +368,7 @@ Feature: TypeDB Driver Queries
         $x isa person;
         $y isa name;
         $f isa friendship;
+      get;
       count;
       """
     Then aggregate value is: 9
@@ -376,6 +378,7 @@ Feature: TypeDB Driver Queries
         $x isa person;
         $y isa name;
         $f (friend: $x) isa friendship;
+      get;
       """
     Then answer size is: 6
     When get answer of typeql get aggregate
@@ -384,6 +387,7 @@ Feature: TypeDB Driver Queries
         $x isa person;
         $y isa name;
         $f (friend: $x) isa friendship;
+      get;
       count;
       """
     Then aggregate value is: 6

--- a/driver/query.feature
+++ b/driver/query.feature
@@ -301,7 +301,7 @@ Feature: TypeDB Driver Queries
       delete $x has name "Alex";
       insert $x has name "Bob";
       """
-    Then session transaction closes
+    Given session transaction closes
 
   #########
   #  GET  #

--- a/driver/query.feature
+++ b/driver/query.feature
@@ -99,7 +99,7 @@ Feature: TypeDB Driver Queries
 
     Given get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -115,7 +115,7 @@ Feature: TypeDB Driver Queries
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -164,7 +164,7 @@ Feature: TypeDB Driver Queries
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -213,7 +213,7 @@ Feature: TypeDB Driver Queries
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 0
 
@@ -312,7 +312,7 @@ Feature: TypeDB Driver Queries
     Given session opens transaction of type: read
     Then typeql get; throws exception
       """
-      match $x isa person; get $y;
+      match $x isa person; get $y; get;
       """
 
   Scenario: Value variables can be specified in a 'get'
@@ -434,11 +434,12 @@ Feature: TypeDB Driver Queries
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     When get answers of typeql get group aggregate
       """
       match ($x, $y) isa friendship;
+      get;
       group $x;
       count;
       """

--- a/query/explanation/language.feature
+++ b/query/explanation/language.feature
@@ -46,7 +46,7 @@ Feature: TypeQL Reasoning Explanation
       $p isa person, has name "Alice";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $p isa person;
       """
@@ -90,7 +90,7 @@ Feature: TypeQL Reasoning Explanation
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
       $k isa area, has name $n;
@@ -147,7 +147,7 @@ Feature: TypeQL Reasoning Explanation
       (superior: $cou, subordinate: $cit) isa location-hierarchy;
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
       $k isa area, has name $n;
@@ -200,7 +200,7 @@ Feature: TypeQL Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $com isa company, has name $n; not { $n "the-company"; };
       """
@@ -247,7 +247,7 @@ Feature: TypeQL Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; $n2 "another-company";};
@@ -295,7 +295,7 @@ Feature: TypeQL Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; {$n2 "another-company";} or {$n2 "third-company";};};

--- a/query/explanation/language.feature
+++ b/query/explanation/language.feature
@@ -48,7 +48,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match $p isa person;
+      match $p isa person; get;
       """
 
     Then uniquely identify answer concepts
@@ -95,6 +95,7 @@ Feature: TypeQL Reasoning Explanation
       match
       $k isa area, has name $n;
       (superior: $l, subordinate: $k) isa location-hierarchy;
+      get;
       """
 
     Then concept identifiers are
@@ -153,6 +154,7 @@ Feature: TypeQL Reasoning Explanation
       $k isa area, has name $n;
       (superior: $l, subordinate: $k) isa location-hierarchy;
       (superior: $u, subordinate: $l) isa location-hierarchy;
+      get;
       """
 
     Then concept identifiers are
@@ -202,7 +204,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match $com isa company, has name $n; not { $n "the-company"; };
+      match $com isa company, has name $n; not { $n "the-company"; }; get;
       """
 
     Then concept identifiers are
@@ -251,6 +253,7 @@ Feature: TypeQL Reasoning Explanation
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; $n2 "another-company";};
+      get;
       """
 
     Then concept identifiers are
@@ -299,6 +302,7 @@ Feature: TypeQL Reasoning Explanation
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; {$n2 "another-company";} or {$n2 "third-company";};};
+      get;
       """
 
     Then concept identifiers are

--- a/query/explanation/reasoner.feature
+++ b/query/explanation/reasoner.feature
@@ -53,7 +53,7 @@ Feature: TypeQL Reasoning Explanation
       $x isa company, has company-id 0;
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $co has name $n;
       """
@@ -115,7 +115,7 @@ Feature: TypeQL Reasoning Explanation
       $co isa company, has company-id 0;
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $co has is-liable $l;
       """
@@ -181,7 +181,7 @@ Feature: TypeQL Reasoning Explanation
       (superior: $cit, subordinate: $ar) isa location-hierarchy;
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
       $k isa area, has name $n;
@@ -276,7 +276,7 @@ Feature: TypeQL Reasoning Explanation
       | a-man-is-called-bob  | { $man isa man; };                                                                  | { $man has name "Bob"; };                         |
       | bobs-sister-is-alice | { $p isa man, has name $nb; $nb "Bob"; $p1 isa woman, has name $na; $na "Alice"; }; | { (sibling: $p, sibling: $p1) isa siblingship; }; |
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match ($w, $m) isa family-relation; $w isa woman;
       """
@@ -293,7 +293,7 @@ Feature: TypeQL Reasoning Explanation
       | 3 | -        | p1, na        | ALI, ALIN            | lookup               | { $p1 isa woman; $p1 has name $na; $na == "Alice"; $p1 iid <answer.p1.iid>; $na iid <answer.na.iid>; };                                                                                           |
       | 4 | -        | man           | BOB                  | lookup               | { $man isa man; $man iid <answer.man.iid>; };                                                                                                                                                    |
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match (sibling: $w, sibling: $m) isa siblingship; $w isa woman;
       """
@@ -349,7 +349,7 @@ Feature: TypeQL Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; $n2 "another-company";};
@@ -414,7 +414,7 @@ Feature: TypeQL Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $com isa company, has is-liable $lia; $lia true;
       """
@@ -478,7 +478,7 @@ Feature: TypeQL Reasoning Explanation
       $c2 has name $n2; $n2 "another-company";
       """
 
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };
       """

--- a/query/explanation/reasoner.feature
+++ b/query/explanation/reasoner.feature
@@ -55,7 +55,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match $co has name $n;
+      match $co has name $n; get;
       """
 
     Then concept identifiers are
@@ -117,7 +117,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match $co has is-liable $l;
+      match $co has is-liable $l; get;
       """
 
     Then concept identifiers are
@@ -186,6 +186,7 @@ Feature: TypeQL Reasoning Explanation
       match
       $k isa area, has name $n;
       (superior: $l, subordinate: $k) isa location-hierarchy;
+      get;
       """
 
     Then concept identifiers are
@@ -278,7 +279,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match ($w, $m) isa family-relation; $w isa woman;
+      match ($w, $m) isa family-relation; $w isa woman; get;
       """
 
     Then uniquely identify answer concepts
@@ -295,7 +296,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match (sibling: $w, sibling: $m) isa siblingship; $w isa woman;
+      match (sibling: $w, sibling: $m) isa siblingship; $w isa woman; get;
       """
 
     Then uniquely identify answer concepts
@@ -354,6 +355,7 @@ Feature: TypeQL Reasoning Explanation
       match $com isa company;
       {$com has name $n1; $n1 "the-company";} or {$com has name $n2; $n2 "another-company";};
       not {$com has is-liable $liability;};
+      get;
       """
 
     Then concept identifiers are
@@ -416,7 +418,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match $com isa company, has is-liable $lia; $lia true;
+      match $com isa company, has is-liable $lia; $lia true; get;
       """
 
     Then concept identifiers are
@@ -480,7 +482,7 @@ Feature: TypeQL Reasoning Explanation
 
     Then get answers of typeql get
       """
-      match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; };
+      match $com isa company; not { $com has is-liable $lia; $lia true; }; not { $com has name $n; $n "the-company"; }; get;
       """
 
     Then concept identifiers are

--- a/query/language/BUILD
+++ b/query/language/BUILD
@@ -23,11 +23,14 @@ files = [
     "define.feature",
     "delete.feature",
     "expression.feature",
+    "fetch.feature",
     "get.feature",
     "insert.feature",
     "match.feature",
+    "modifiers.feature",
     "rule-validation.feature",
     "undefine.feature",
+    "update.feature",
 ]
 
 filegroup(

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -57,7 +57,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type dog;
       """
@@ -74,7 +74,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub person;
       """
@@ -134,7 +134,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays employment:employee;
       """
@@ -155,7 +155,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays employment:employee;
       """
@@ -175,7 +175,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns name;
       """
@@ -196,7 +196,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns name;
       """
@@ -216,7 +216,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email @key;
       """
@@ -237,7 +237,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email @key;
       """
@@ -260,7 +260,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays home-ownership:home;
       """
@@ -279,7 +279,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns price;
       """
@@ -298,7 +298,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns address @key;
       """
@@ -376,7 +376,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type pet-ownership;
       """
@@ -393,7 +393,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub employment;
       """
@@ -419,7 +419,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates employee;
       """
@@ -442,7 +442,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x relates parent;
@@ -451,7 +451,7 @@ Feature: TypeQL Define Query
     Then uniquely identify answer concepts
       | x                |
       | label:parenthood |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x relates father;
@@ -472,7 +472,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $x sub parenthood:parent; $y sub parenthood:child; get $x, $y;
@@ -493,7 +493,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates employee;
       """
@@ -521,7 +521,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates preferred-plane;
       """
@@ -564,7 +564,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays income:source;
       """
@@ -585,7 +585,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays income:source;
       """
@@ -614,7 +614,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns start-date;
       """
@@ -635,7 +635,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns start-date;
       """
@@ -655,7 +655,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns employment-reference-code @key;
       """
@@ -676,7 +676,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns employment-reference-code @key;
       """
@@ -696,7 +696,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type connection;
       """
@@ -715,7 +715,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates parent; $x relates child;
       """
@@ -734,7 +734,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates owner;
       """
@@ -756,7 +756,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type <label>;
@@ -797,7 +797,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub code;
       """
@@ -817,7 +817,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type door-code, value string;
       """
@@ -844,7 +844,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x regex "^(yes|no|maybe)$";
       """
@@ -872,7 +872,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays car-sales-listing:available-colour;
       """
@@ -896,7 +896,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays phone-contact:number;
       """
@@ -919,7 +919,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns brightness;
       """
@@ -942,7 +942,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns country-calling-code;
       """
@@ -965,7 +965,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns hex-value @key;
       """
@@ -988,7 +988,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns hex-value @key;
       """
@@ -1010,7 +1010,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns <label>;
       """
@@ -1045,7 +1045,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type animal; $x abstract;
       """
@@ -1064,7 +1064,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub animal;
       """
@@ -1084,7 +1084,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub animal; $x abstract;
       """
@@ -1104,7 +1104,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub exception, abstract;
       """
@@ -1121,7 +1121,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type membership; $x abstract;
       """
@@ -1140,7 +1140,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub membership;
       """
@@ -1160,7 +1160,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub requirement; $x abstract;
       """
@@ -1180,7 +1180,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub requirement; $x abstract;
       """
@@ -1197,7 +1197,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type number-of-limbs; $x abstract;
       """
@@ -1216,7 +1216,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub number-of-limbs;
       """
@@ -1236,7 +1236,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub number-of-limbs; $x abstract;
       """
@@ -1259,7 +1259,7 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
     Then session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $name type super-name, abstract;
@@ -1298,7 +1298,7 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Then session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $t owns $a @key;
       """
@@ -1307,7 +1307,7 @@ Feature: TypeQL Define Query
       | label:person     | label:email                     |
       | label:child      | label:email                     |
       | label:employment | label:employment-reference-code |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $t owns $a @unique;
       """
@@ -1340,7 +1340,7 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Then session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $t owns $a @unique;
       """
@@ -1358,7 +1358,7 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Then session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $t owns $a @unique;
       """
@@ -1408,7 +1408,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type person, owns name;
       """
@@ -1446,7 +1446,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns name;
       """
@@ -1464,7 +1464,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays employment:employee;
       """
@@ -1507,7 +1507,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns barcode @key;
       """
@@ -1586,7 +1586,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates employer;
       """
@@ -1630,7 +1630,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Then session opens transaction of type: read
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $x regex "^A.*$";
       """
@@ -1707,7 +1707,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns name @key;
       """
@@ -1724,14 +1724,14 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email;
       """
     Then uniquely identify answer concepts
       | x            |
       | label:person |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email @key;
       """
@@ -1812,7 +1812,7 @@ Feature: TypeQL Define Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns $y @unique;
       """
@@ -1820,7 +1820,7 @@ Feature: TypeQL Define Query
       | x            | y              |
       | label:person | label:email    |
       | label:person | label:phone-nr |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match person owns $y @key;
       """
@@ -1959,7 +1959,7 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name $a;
       """
@@ -1978,7 +1978,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub person; $x abstract;
       """
@@ -2001,7 +2001,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub friendship, abstract;
       """
@@ -2023,7 +2023,7 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub age, abstract;
       """
@@ -2125,7 +2125,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub apple-product;
       """
@@ -2169,7 +2169,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub shoe-size;
       """
@@ -2199,7 +2199,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub organism;
       """
@@ -2240,7 +2240,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub pigeon;
       """
@@ -2280,7 +2280,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub pigeon;
       """
@@ -2320,7 +2320,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub pigeon;
       """
@@ -2366,7 +2366,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type child, plays $r;
       """
@@ -2388,7 +2388,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type child, owns $y;
       """
@@ -2411,7 +2411,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type child, owns $y @key;
       """
@@ -2431,7 +2431,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type part-time-employment, relates $r;
       """
@@ -2455,7 +2455,7 @@ Feature: TypeQL Define Query
       define dog sub entity;
       """
     When session opens transaction of type: read
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x type dog;
       """
@@ -2492,7 +2492,7 @@ Feature: TypeQL Define Query
       middlename sub attribute, value string, owns firstname;
       firstname sub attribute, value string, owns surname;
       """
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $a sub attribute, owns $b; $b sub attribute, owns $a;
       """
@@ -2500,7 +2500,7 @@ Feature: TypeQL Define Query
       | a              | b              |
       | label:nickname | label:surname  |
       | label:surname  | label:nickname |
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $a owns $b; $b owns $a;
       """
@@ -2518,7 +2518,7 @@ Feature: TypeQL Define Query
       middlename sub attribute, value string, owns firstname;
       firstname sub attribute, value string, owns surname;
       """
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
       $a sub attribute, owns $b;
@@ -2544,7 +2544,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates function; $x plays recursive-function:function;
       """
@@ -2561,7 +2561,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns number-of-letters;
       """

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -59,7 +59,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type dog;
+      match $x type dog; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -76,7 +76,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub person;
+      match $x sub person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -136,7 +136,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays employment:employee;
+      match $x plays employment:employee; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -157,7 +157,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays employment:employee;
+      match $x plays employment:employee; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -177,7 +177,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns name;
+      match $x owns name; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -198,7 +198,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns name;
+      match $x owns name; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -218,7 +218,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns email @key;
+      match $x owns email @key; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -239,7 +239,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns email @key;
+      match $x owns email @key; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -262,7 +262,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays home-ownership:home;
+      match $x plays home-ownership:home; get;
       """
     Then uniquely identify answer concepts
       | x           |
@@ -281,7 +281,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns price;
+      match $x owns price; get;
       """
     Then uniquely identify answer concepts
       | x           |
@@ -300,7 +300,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns address @key;
+      match $x owns address @key; get;
       """
     Then uniquely identify answer concepts
       | x           |
@@ -378,7 +378,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type pet-ownership;
+      match $x type pet-ownership; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -395,7 +395,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub employment;
+      match $x sub employment; get;
       """
     Then uniquely identify answer concepts
       | x                    |
@@ -421,7 +421,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates employee;
+      match $x relates employee; get;
       """
     Then uniquely identify answer concepts
       | x                          |
@@ -447,6 +447,7 @@ Feature: TypeQL Define Query
       match
         $x relates parent;
         $x relates child;
+      get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -456,6 +457,7 @@ Feature: TypeQL Define Query
       match
         $x relates father;
         $x relates son;
+      get;
       """
     Then uniquely identify answer concepts
       | x                    |
@@ -495,7 +497,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates employee;
+      match $x relates employee; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -523,7 +525,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates preferred-plane;
+      match $x relates preferred-plane; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -566,7 +568,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays income:source;
+      match $x plays income:source; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -587,7 +589,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays income:source;
+      match $x plays income:source; get;
       """
     Then uniquely identify answer concepts
       | x                                 |
@@ -616,7 +618,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns start-date;
+      match $x owns start-date; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -637,7 +639,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns start-date;
+      match $x owns start-date; get;
       """
     Then uniquely identify answer concepts
       | x                                 |
@@ -657,7 +659,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns employment-reference-code @key;
+      match $x owns employment-reference-code @key; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -678,7 +680,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns employment-reference-code @key;
+      match $x owns employment-reference-code @key; get;
       """
     Then uniquely identify answer concepts
       | x                                 |
@@ -698,7 +700,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type connection;
+      match $x type connection; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -717,7 +719,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates parent; $x relates child;
+      match $x relates parent; $x relates child; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -736,7 +738,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates owner;
+      match $x relates owner; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -761,6 +763,7 @@ Feature: TypeQL Define Query
       match
         $x type <label>;
         $x sub attribute;
+      get;
       """
     Then answer size is: 1
 
@@ -799,7 +802,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub code;
+      match $x sub code; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -819,7 +822,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type door-code, value string;
+      match $x type door-code, value string; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -846,7 +849,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x regex "^(yes|no|maybe)$";
+      match $x regex "^(yes|no|maybe)$"; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -874,7 +877,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays car-sales-listing:available-colour;
+      match $x plays car-sales-listing:available-colour; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -898,7 +901,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays phone-contact:number;
+      match $x plays phone-contact:number; get;
       """
     Then uniquely identify answer concepts
       | x                                |
@@ -921,7 +924,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns brightness;
+      match $x owns brightness; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -944,7 +947,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns country-calling-code;
+      match $x owns country-calling-code; get;
       """
     Then uniquely identify answer concepts
       | x                                |
@@ -967,7 +970,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns hex-value @key;
+      match $x owns hex-value @key; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -990,7 +993,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns hex-value @key;
+      match $x owns hex-value @key; get;
       """
     Then uniquely identify answer concepts
       | x                          |
@@ -1012,7 +1015,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns <label>;
+      match $x owns <label>; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -1047,7 +1050,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type animal; $x abstract;
+      match $x type animal; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -1066,7 +1069,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub animal;
+      match $x sub animal; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -1086,7 +1089,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub animal; $x abstract;
+      match $x sub animal; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -1106,7 +1109,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub exception, abstract;
+      match $x sub exception, abstract; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -1123,7 +1126,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type membership; $x abstract;
+      match $x type membership; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -1142,7 +1145,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub membership;
+      match $x sub membership; get;
       """
     Then uniquely identify answer concepts
       | x                    |
@@ -1162,7 +1165,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub requirement; $x abstract;
+      match $x sub requirement; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -1182,7 +1185,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub requirement; $x abstract;
+      match $x sub requirement; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -1199,7 +1202,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type number-of-limbs; $x abstract;
+      match $x type number-of-limbs; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x                     |
@@ -1218,7 +1221,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub number-of-limbs;
+      match $x sub number-of-limbs; get;
       """
     Then uniquely identify answer concepts
       | x                     |
@@ -1238,7 +1241,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub number-of-limbs; $x abstract;
+      match $x sub number-of-limbs; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x                                |
@@ -1264,6 +1267,7 @@ Feature: TypeQL Define Query
       match
       $name type super-name, abstract;
       $location type location-name, sub super-name;
+      get;
       """
     Then uniquely identify answer concepts
       | name             | location            |
@@ -1300,7 +1304,7 @@ Feature: TypeQL Define Query
     Then session opens transaction of type: read
     When get answers of typeql get
       """
-      match $t owns $a @key;
+      match $t owns $a @key; get;
       """
     Then uniquely identify answer concepts
       | t                | a                               |
@@ -1309,7 +1313,7 @@ Feature: TypeQL Define Query
       | label:employment | label:employment-reference-code |
     When get answers of typeql get
       """
-      match $t owns $a @unique;
+      match $t owns $a @unique; get;
       """
     Then uniquely identify answer concepts
       | t             | a               |
@@ -1342,7 +1346,7 @@ Feature: TypeQL Define Query
     Then session opens transaction of type: write
     When get answers of typeql get
       """
-      match $t owns $a @unique;
+      match $t owns $a @unique; get;
       """
     Then uniquely identify answer concepts
       | t             | a               |
@@ -1360,7 +1364,7 @@ Feature: TypeQL Define Query
     Then session opens transaction of type: read
     When get answers of typeql get
       """
-      match $t owns $a @unique;
+      match $t owns $a @unique; get;
       """
     Then uniquely identify answer concepts
       | t             | a                   |
@@ -1410,7 +1414,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type person, owns name;
+      match $x type person, owns name; get;
       """
     Then answer size is: 1
 
@@ -1448,7 +1452,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns name;
+      match $x owns name; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -1466,7 +1470,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays employment:employee;
+      match $x plays employment:employee; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -1509,7 +1513,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns barcode @key;
+      match $x owns barcode @key; get;
       """
     Then uniquely identify answer concepts
       | x             |
@@ -1588,7 +1592,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates employer;
+      match $x relates employer; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -1632,7 +1636,7 @@ Feature: TypeQL Define Query
     Then session opens transaction of type: read
     Then get answers of typeql get
       """
-      match $x regex "^A.*$";
+      match $x regex "^A.*$"; get;
       """
     Then uniquely identify answer concepts
       | x          |
@@ -1709,7 +1713,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns name @key;
+      match $x owns name @key; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -1726,14 +1730,14 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns email;
+      match $x owns email; get;
       """
     Then uniquely identify answer concepts
       | x            |
       | label:person |
     When get answers of typeql get
       """
-      match $x owns email @key;
+      match $x owns email @key; get;
       """
     Then answer size is: 0
 
@@ -1814,7 +1818,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x owns $y @unique;
+      match $x owns $y @unique; get;
       """
     Then uniquely identify answer concepts
       | x            | y              |
@@ -1822,7 +1826,7 @@ Feature: TypeQL Define Query
       | label:person | label:phone-nr |
     When get answers of typeql get
       """
-      match person owns $y @key;
+      match person owns $y @key; get;
       """
     Then answer size is: 0
     Given typeql insert; throws exception
@@ -1961,7 +1965,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has name $a;
+      match $x has name $a; get;
       """
     Then answer size is: 1
 
@@ -1980,7 +1984,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub person; $x abstract;
+      match $x sub person; $x abstract; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -2003,7 +2007,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub friendship, abstract;
+      match $x sub friendship, abstract; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -2025,7 +2029,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub age, abstract;
+      match $x sub age, abstract; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -2127,7 +2131,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub apple-product;
+      match $x sub apple-product; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -2171,7 +2175,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub shoe-size;
+      match $x sub shoe-size; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -2201,7 +2205,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub organism;
+      match $x sub organism; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -2242,7 +2246,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub pigeon;
+      match $x sub pigeon; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -2282,7 +2286,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub pigeon;
+      match $x sub pigeon; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -2322,7 +2326,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub pigeon;
+      match $x sub pigeon; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -2368,7 +2372,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type child, plays $r;
+      match $x type child, plays $r; get;
       """
     Then uniquely identify answer concepts
       | x           | r                         |
@@ -2390,7 +2394,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type child, owns $y;
+      match $x type child, owns $y; get;
       """
     Then uniquely identify answer concepts
       | x           | y                  |
@@ -2413,7 +2417,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type child, owns $y @key;
+      match $x type child, owns $y @key; get;
       """
     Then uniquely identify answer concepts
       | x           | y                  |
@@ -2433,7 +2437,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type part-time-employment, relates $r;
+      match $x type part-time-employment, relates $r; get;
       """
     Then uniquely identify answer concepts
       | x                          | r                         |
@@ -2457,7 +2461,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     Then typeql get; throws exception
       """
-      match $x type dog;
+      match $x type dog; get;
       """
 
 
@@ -2494,7 +2498,7 @@ Feature: TypeQL Define Query
       """
     Then get answers of typeql get
       """
-      match $a sub attribute, owns $b; $b sub attribute, owns $a;
+      match $a sub attribute, owns $b; $b sub attribute, owns $a; get;
       """
     Then uniquely identify answer concepts
       | a              | b              |
@@ -2502,7 +2506,7 @@ Feature: TypeQL Define Query
       | label:surname  | label:nickname |
     Then get answers of typeql get
       """
-      match $a owns $b; $b owns $a;
+      match $a owns $b; $b owns $a; get;
       """
     Then uniquely identify answer concepts
       | a              | b              |
@@ -2525,6 +2529,7 @@ Feature: TypeQL Define Query
       $b sub attribute, owns $c;
       $c sub attribute, owns $d;
       $d sub attribute, owns $a;
+      get;
       """
     Then uniquely identify answer concepts
       | a                | b                | c                | d                |
@@ -2546,7 +2551,7 @@ Feature: TypeQL Define Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates function; $x plays recursive-function:function;
+      match $x relates function; $x plays recursive-function:function; get;
       """
     Then uniquely identify answer concepts
       | x                        |
@@ -2563,7 +2568,7 @@ Feature: TypeQL Define Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns number-of-letters;
+      match $x owns number-of-letters; get;
       """
     Then uniquely identify answer concepts
       | x                       |

--- a/query/language/delete.feature
+++ b/query/language/delete.feature
@@ -88,19 +88,19 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x            |
       | key:name:Bob |
     When get answers of typeql get
       """
-      match $x isa friendship;
+      match $x isa friendship; get;
       """
     Then answer size is: 0
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -135,7 +135,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -169,7 +169,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -203,7 +203,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa friendship;
+      match $x isa friendship; get;
       """
     Then answer size is: 0
 
@@ -231,7 +231,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Then answer size is: 0
 
@@ -263,7 +263,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -294,7 +294,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 0
 
@@ -414,6 +414,7 @@ Feature: TypeQL Delete Query
       match
       $x isa person;
       $r ($x) isa friendship;
+      get;
       """
     Then answer size is: 0
 
@@ -454,7 +455,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match (friend: $x, friend: $y) isa friendship;
+      match (friend: $x, friend: $y) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | x               | y               |
@@ -489,7 +490,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -497,7 +498,7 @@ Feature: TypeQL Delete Query
       | key:name:Carrie |
     When get answers of typeql get
       """
-      match $r (friend: $x) isa friendship;
+      match $r (friend: $x) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | r         | x               |
@@ -530,7 +531,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (friend: $x) isa friendship;
+      match $r (friend: $x) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | r         | x            |
@@ -562,7 +563,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (friend: $x, friend: $y) isa friendship;
+      match $r (friend: $x, friend: $y) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | r         | x             | y             |
@@ -596,7 +597,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (friend: $x, friend: $y) isa friendship;
+      match $r (friend: $x, friend: $y) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | r         | x             | y             |
@@ -630,7 +631,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (friend: $x, friend: $y) isa friendship;
+      match $r (friend: $x, friend: $y) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | r         | x             | y             |
@@ -689,7 +690,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $r (friend: $x, friend: $y) isa friendship;
+      match $r (friend: $x, friend: $y) isa friendship; get;
       """
     Then answer size is: 0
 
@@ -704,7 +705,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $r has email $a, has email $b;
+      match $r has email $a, has email $b; get;
       """
     Then answer size is: 0
 
@@ -721,7 +722,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa person; $y isa person;
+      match $x isa person; $y isa person; get;
       """
     Then answer size is: 0
 
@@ -792,7 +793,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r isa friendship;
+      match $r isa friendship; get;
       """
     Then answer size is: 0
 
@@ -824,7 +825,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r isa friendship;
+      match $r isa friendship; get;
       """
     Then answer size is: 0
 
@@ -957,7 +958,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $rel (chef: $p) isa ship-crew;
+      match $rel (chef: $p) isa ship-crew; get;
       """
     Then uniquely identify answer concepts
       | rel       | p               |
@@ -974,7 +975,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $rel (chef: $p) isa ship-crew;
+      match $rel (chef: $p) isa ship-crew; get;
       """
     Then answer size is: 0
 
@@ -1008,7 +1009,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x has age 18;
+      match $x has age 18; get;
       """
     Then uniquely identify answer concepts
       | x             |
@@ -1025,7 +1026,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has age 18;
+      match $x has age 18; get;
       """
     Then answer size is: 0
 
@@ -1125,7 +1126,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 0
 
@@ -1175,7 +1176,7 @@ Feature: TypeQL Delete Query
     Given session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x has duration $d;
+      match $x has duration $d; get;
       """
     Then uniquely identify answer concepts
       | x         | d                   |
@@ -1192,7 +1193,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has duration $d;
+      match $x has duration $d; get;
       """
     Then answer size is: 0
 
@@ -1223,7 +1224,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x has duration $d;
+      match $x has duration $d; get;
       """
     Then uniquely identify answer concepts
       | x         | d                   |
@@ -1240,12 +1241,12 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has duration $d;
+      match $x has duration $d; get;
       """
     Then answer size is: 0
     When get answers of typeql get
       """
-      match $r isa friendship;
+      match $r isa friendship; get;
       """
     Then answer size is: 0
 
@@ -1312,7 +1313,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $f (friend: $x) isa friendship;
+      match $f (friend: $x) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | f         | x             |
@@ -1321,7 +1322,7 @@ Feature: TypeQL Delete Query
       | key:ref:3 | key:name:Alex |
     When get answers of typeql get
       """
-      match $n isa name;
+      match $n isa name; get;
       """
     Then uniquely identify answer concepts
       | n               |
@@ -1329,7 +1330,7 @@ Feature: TypeQL Delete Query
       | attr:name:Alex  |
     When get answers of typeql get
       """
-      match $x isa person, has lastname $n;
+      match $x isa person, has lastname $n; get;
       """
     Then uniquely identify answer concepts
       | x             | n                    |
@@ -1385,7 +1386,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person, has lastname $n;
+      match $x isa person, has lastname $n; get;
       """
     Then answer size is: 0
 
@@ -1397,7 +1398,7 @@ Feature: TypeQL Delete Query
   Scenario: deleting a variable not in the query throws, even if there were no matches
     Then typeql delete; throws exception
       """
-      match $x isa person; delete $n isa name;
+      match $x isa person; delete $n isa name; get;
       """
 
 
@@ -1432,7 +1433,7 @@ Feature: TypeQL Delete Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Then uniquely identify answer concepts
       | x                  |

--- a/query/language/delete.feature
+++ b/query/language/delete.feature
@@ -409,7 +409,7 @@ Feature: TypeQL Delete Query
     Given transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $x isa person;
@@ -687,7 +687,7 @@ Feature: TypeQL Delete Query
       """
     Given transaction commits
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -702,7 +702,7 @@ Feature: TypeQL Delete Query
       """
     Given transaction commits
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r has email $a, has email $b;
       """
@@ -719,7 +719,7 @@ Feature: TypeQL Delete Query
       """
     Given transaction commits
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person; $y isa person;
       """

--- a/query/language/delete.feature
+++ b/query/language/delete.feature
@@ -86,19 +86,19 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
     Then uniquely identify answer concepts
       | x            |
       | key:name:Bob |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa friendship;
       """
     Then answer size is: 0
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -133,7 +133,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -167,7 +167,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -201,7 +201,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa friendship;
       """
@@ -229,7 +229,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -261,7 +261,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -292,7 +292,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -452,7 +452,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (friend: $x, friend: $y) isa friendship;
       """
@@ -487,7 +487,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -495,7 +495,7 @@ Feature: TypeQL Delete Query
       | x               |
       | key:name:Bob    |
       | key:name:Carrie |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (friend: $x) isa friendship;
       """
@@ -528,7 +528,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (friend: $x) isa friendship;
       """
@@ -560,7 +560,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -594,7 +594,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -628,7 +628,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
@@ -790,7 +790,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r isa friendship;
       """
@@ -822,7 +822,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r isa friendship;
       """
@@ -955,7 +955,7 @@ Feature: TypeQL Delete Query
     Given transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $rel (chef: $p) isa ship-crew;
       """
@@ -972,7 +972,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $rel (chef: $p) isa ship-crew;
       """
@@ -1006,7 +1006,7 @@ Feature: TypeQL Delete Query
     Given transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age 18;
       """
@@ -1023,7 +1023,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age 18;
       """
@@ -1123,7 +1123,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -1173,7 +1173,7 @@ Feature: TypeQL Delete Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has duration $d;
       """
@@ -1190,7 +1190,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has duration $d;
       """
@@ -1221,7 +1221,7 @@ Feature: TypeQL Delete Query
     Given transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has duration $d;
       """
@@ -1238,12 +1238,12 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has duration $d;
       """
     Then answer size is: 0
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r isa friendship;
       """
@@ -1310,7 +1310,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $f (friend: $x) isa friendship;
       """
@@ -1319,7 +1319,7 @@ Feature: TypeQL Delete Query
       | key:ref:2 | key:name:Alex |
       | key:ref:2 | key:name:John |
       | key:ref:3 | key:name:Alex |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $n isa name;
       """
@@ -1327,7 +1327,7 @@ Feature: TypeQL Delete Query
       | n               |
       | attr:name:John  |
       | attr:name:Alex  |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has lastname $n;
       """
@@ -1383,7 +1383,7 @@ Feature: TypeQL Delete Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has lastname $n;
       """
@@ -1430,7 +1430,7 @@ Feature: TypeQL Delete Query
     Given transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -16,7 +16,7 @@
 #
 
 #noinspection CucumberUndefinedStep
-Feature: TypeQL Match Query with Expressions
+Feature: TypeQL Get Query with Expressions
 
   Background: Open connection and create a simple extensible schema
     Given typedb starts
@@ -50,7 +50,7 @@ Feature: TypeQL Match Query with Expressions
     Given connection open data session for database: typedb
 
     Given session opens transaction of type: read
-    When typeql match; throws exception containing "value variable '?v' is never assigned to"
+    When typeql get; throws exception containing "value variable '?v' is never assigned to"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -61,7 +61,7 @@ Feature: TypeQL Match Query with Expressions
       """
 
     Given session opens transaction of type: read
-    When typeql match; throws exception containing "value variable '?v' can only have one assignment in the first scope"
+    When typeql get; throws exception containing "value variable '?v' can only have one assignment in the first scope"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -75,7 +75,7 @@ Feature: TypeQL Match Query with Expressions
   Scenario: A value variable must have exactly one assignment constraint recursively
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    When typeql match; throws exception containing "value variable '?v' can only have one assignment in the first scope"
+    When typeql get; throws exception containing "value variable '?v' can only have one assignment in the first scope"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -89,7 +89,7 @@ Feature: TypeQL Match Query with Expressions
   Scenario: A value variable's assignment must be in the highest scope
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    When typeql match; throws exception containing "value variable '?v' can only have one assignment in the first scope"
+    When typeql get; throws exception containing "value variable '?v' can only have one assignment in the first scope"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -104,7 +104,7 @@ Feature: TypeQL Match Query with Expressions
     Given connection open data session for database: typedb
 
     Given session opens transaction of type: read
-    When typeql match; throws exception containing "cyclic assignment between value variables was detected"
+    When typeql get; throws exception containing "cyclic assignment between value variables was detected"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -114,7 +114,7 @@ Feature: TypeQL Match Query with Expressions
       """
 
     Given session opens transaction of type: read
-    When typeql match; throws exception containing "cyclic assignment between value variables was detected"
+    When typeql get; throws exception containing "cyclic assignment between value variables was detected"
     """
       match
         $x isa person, has age $a, has age $h;
@@ -139,7 +139,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $z isa person, has name $x, has age $y;
@@ -166,7 +166,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match; throws exception containing "The variable(s) named 'y' cannot be used for both concept variables and a value variables"
+    Then typeql get; throws exception containing "The variable(s) named 'y' cannot be used for both concept variables and a value variables"
       """
       match
         $z isa person, has age $y;
@@ -187,7 +187,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
         $x isa age;
@@ -204,7 +204,7 @@ Feature: TypeQL Match Query with Expressions
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6.0 + 3.0;
@@ -218,7 +218,7 @@ Feature: TypeQL Match Query with Expressions
       | a                 | b                 | c                  | d                  |
       | value:double: 9.0 | value:double: 3.0 | value:double: 18.0 | value:double: 2.0  |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6 + 3;
@@ -232,7 +232,7 @@ Feature: TypeQL Match Query with Expressions
       | a             | b            | c             | d                  |
       | value:long: 9 | value:long:3 | value:long:18 | value:double: 2.0  |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6.0 + 3;
@@ -246,7 +246,7 @@ Feature: TypeQL Match Query with Expressions
       | a                 | b                 | c                  | d                  |
       | value:double: 9.0 | value:double: 3.0 | value:double: 18.0 | value:double: 2.0  |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = 6 + 3.0;
@@ -265,7 +265,7 @@ Feature: TypeQL Match Query with Expressions
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = floor(3/2);
@@ -277,7 +277,7 @@ Feature: TypeQL Match Query with Expressions
       | a             | b             |
       | value:long: 1 | value:long: 2 |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = round(2/3);
@@ -289,7 +289,7 @@ Feature: TypeQL Match Query with Expressions
       | a             | b                 |
       | value:long: 1 | value:double: 0.5 |
 
-    When get answers of typeql match
+    When get answers of typeql get
     """
       match
         ?a = max(2, -3);
@@ -317,7 +317,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name,
@@ -351,7 +351,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -366,7 +366,7 @@ Feature: TypeQL Match Query with Expressions
       | attr:name:b22.2 |
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -396,7 +396,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -412,7 +412,7 @@ Feature: TypeQL Match Query with Expressions
       | attr:name:b22.2 |
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -443,7 +443,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -459,7 +459,7 @@ Feature: TypeQL Match Query with Expressions
       | attr:name:b22.2 |
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -490,7 +490,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -506,7 +506,7 @@ Feature: TypeQL Match Query with Expressions
       | attr:name:b22.2 |
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $p isa person, has name $name, has height $h, has weight $w;
@@ -536,7 +536,7 @@ Feature: TypeQL Match Query with Expressions
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match; throws exception containing "division by zero"
+    Then typeql get; throws exception containing "division by zero"
       """
       match
         $p isa person, has age $a;

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -194,6 +194,7 @@ Feature: TypeQL Get Query with Expressions
         ?const = -10;
         ?plus-negative = $x + -10;
         ?minus-negative = $x - -10;
+      get;
       """
     Then uniquely identify answer concepts
       | x            | const           | plus-negative  | minus-negative  |

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -86,6 +86,35 @@ Feature: TypeQL Fetch Query
         "p": { "root": "entity", "label": "person" }
       }]
       """
+    When get answers of typeql fetch
+      """
+      match
+      $p type friendship:friend;
+      fetch
+      $p;
+      """
+    Then fetch answers are
+      """
+      [{
+        "p": { "root": "relation:role", "label": "friendship:friend" }
+      }]
+      """
+
+  # TODO: remove this scenario when we finish deprecating 'thing' type
+  Scenario: root thing type can be fetched
+    When get answers of typeql fetch
+      """
+      match
+      $p type thing;
+      fetch
+      $p;
+      """
+    Then fetch answers are
+      """
+      [{
+        "p": { "root": "thing", "label": "thing" }
+      }]
+      """
 
 
   Scenario: an attribute can be fetched

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -164,6 +164,7 @@ Feature: TypeQL Fetch Query
       }]
       """
 
+
   Scenario: a value can be fetched
     When get answers of typeql fetch
       """

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -173,7 +173,7 @@ Feature: TypeQL Fetch Query
       """
 
 
-  Feature: a subquery can be fetched
+  Feature: a fetch subquery can be a match-fetch query
     When get answers of typeql fetch
       """
       match
@@ -216,6 +216,48 @@ Feature: TypeQL Fetch Query
          age: [ ]
        },
        employers: [ ]
+      }]
+      """
+
+
+  Feature: a fetch subquery can be a match-aggregate query
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      fetch
+      $p: person-name, age;
+      employment-count: {
+        match
+        $r (employee: $p, employer: $c) isa employment;
+        get $r;
+        count;
+      };
+      sort $n;
+      """
+    Then fetch answers are
+      """
+      [{
+        p: {
+          type: 'person',
+          person-name: [
+            { type: 'person-name', value: 'Alice' }
+          ],
+          age: [
+            { type: 'age', value: 10 }
+          ]
+        },
+        employer-count: { value: 1 }
+      },
+      {
+        p: {
+         type: 'person',
+         person-name: [
+           { type: 'person-name', value: 'Bob' }
+         ],
+         age: [ ]
+       },
+       employment-count: { value: 0 }
       }]
       """
 

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -62,8 +62,8 @@ Feature: TypeQL Fetch Query
       """
       insert
       $p1 isa person, has person-name "Alice", has person-name "Allie", has age 10, has ref 0;
-      $p2 isa person, has person-name "Bob", ref 1;
-      $c1 isa company, has company-name "Vaticle", has ref 2
+      $p2 isa person, has person-name "Bob", has ref 1;
+      $c1 isa company, has company-name "Vaticle", has ref 2;
       $f1 (friend: $p1, friend: $p2) isa friendship, has ref 3;
       $e1 (employee: $p1, employer: $c1) isa employment, has ref 4;
       """
@@ -72,7 +72,7 @@ Feature: TypeQL Fetch Query
     Given session opens transaction of type: read
 
 
-  Feature: a type can be fetched
+  Scenario: a type can be fetched
     When get answers of typeql fetch
       """
       match
@@ -83,12 +83,12 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        p: { label: 'person' }
+        "p": { "root": "entity", "label": "person" }
       }]
       """
 
 
-  Feature: an attribute can be fetched
+  Scenario: an attribute can be fetched
     When get answers of typeql fetch
       """
       match
@@ -100,21 +100,21 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        a: { type: 'person-name', value: 'Alice' }
+        "a": { "value":"Alice", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
       },
       {
-        a: { type: 'person-name', value: 'Allie' }
+        "a": { "value":"Allie", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
       },
       {
-        a: { type: 'person-name', value: 'Bob' }
+        "a": { "value":"Bob", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
       },
       {
-        a: { type: 'company-name', value: 'Vaticle' }
+        "a": { "value":"Vaticle", "value_type": "string", "type": { "root": "attribute", "label": "company-name" } }
       }]
       """
 
 
-  Feature: a value can be fetched
+  Scenario: a value can be fetched
     When get answers of typeql fetch
       """
       match
@@ -127,21 +127,21 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        v: { value: 'Alice' }
+        "v": { "value":"Alice", "value_type": "string" }
       },
       {
-        v: { value: 'Allie' }
+        "v": { "value":"Allie", "value_type": "string" }
       },
       {
-        v: { value: 'Bob' }
+        "v": { "value":"Bob", "value_type": "string" }
       },
       {
-        v: { value: 'Vaticle' }
+        "v": { "value":"Vaticle", "value_type": "string" }
       }]
       """
 
 
-  Feature: a concept's attributes can be fetched
+  Scenario: a concept's attributes can be fetched
     When get answers of typeql fetch
       """
       match
@@ -153,56 +153,61 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        p: {
-          type: 'person',
-          person-name: [
-            { type: 'person-name', value: 'Alice' },
-            { type: 'person-name', value: 'Allie' }
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "person-name": [
+            { "value":"Alice", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } },
+            { "value":"Allie", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
           ],
-          age: [
-            { type: 'age', value: 10 }
+          "age": [
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
           ]
+        }
       },
-        p: {
-          type: 'person',
-          person-name: [
-            { type: 'person-name', value: 'Bob' }
+      {
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "person-name": [
+            { "value":"Bob", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
           ],
-          age: [ ]
+          "age": []
+        }
       }]
       """
 
 
-  Feature: a concept's attributes can be fetched using more general types than the concept type owns
+  Scenario: a concept's attributes can be fetched using more general types than the concept type owns
     When get answers of typeql fetch
       """
       match
-      $p isa person, has person-name 'Alice';
+      $p isa person, has person-name "Alice";
       fetch
       $p: attribute;
       """
     Then fetch answers are
       """
       [{
-        p: {
-          type: 'person',
-          attribute: [
-            { type: 'person-name', value: 'Alice' },
-            { type: 'age', value: 10 },
-            { type: 'person-name', value: 'Allie' }
-          ],
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "attribute": [
+            { "value": "Alice", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } },
+            { "value": "Allie", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } },
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } },
+            { "value": 0, "value_type": "long", "type": { "root": "attribute", "label": "ref" } }
+          ]
+        }
       }]
       """
 
 
-  Feature: a fetch subquery can be a match-fetch query
+  Scenario: a fetch subquery can be a match-fetch query
     When get answers of typeql fetch
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name, age;
-      employers: {
+      "employers": {
         match
         (employee: $p, employer: $c) isa employment;
         fetch
@@ -213,40 +218,45 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        p: {
-          type: 'person',
-          person-name: [
-            { type: 'person-name', value: 'Alice' }
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "person-name": [
+            { "value":"Alice", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } },
+            { "value":"Allie", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
           ],
-          age: [
-            { type: 'age', value: 10 }
+          "age": [
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
           ]
         },
-        employers: [
-          c: {
-            type: 'company',
-            name: [ { type: 'company-name', value: 'Vaticle' }]
+        "employers": [
+          {
+            "c": {
+              "type": { "root": "entity", "label": "company" },
+              "name": [
+                { "value": "Vaticle", "value_type": "string", "type": { "root": "attribute", "label": "company-name" } }
+              ]
+            }
           }
         ]
       },
       {
-        p: {
-         type: 'person',
-         person-name: [
-           { type: 'person-name', value: 'Bob' }
-         ],
-         age: [ ]
-       },
-       employers: [ ]
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "person-name": [
+            { "value":"Bob", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
+          ],
+          "age": [ ]
+        },
+        "employers": [ ]
       }]
       """
 
 
-  Feature: a fetch subquery can be a match-aggregate query
+  Scenario: a fetch subquery can be a match-aggregate query
     When get answers of typeql fetch
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name, age;
       employment-count: {
@@ -260,31 +270,97 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        p: {
-          type: 'person',
-          person-name: [
-            { type: 'person-name', value: 'Alice' }
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "person-name": [
+            { "value":"Alice", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } },
+            { "value":"Allie", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
           ],
-          age: [
-            { type: 'age', value: 10 }
+          "age": [
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
           ]
         },
-        employer-count: { value: 1 }
+        "employment-count": { "value":1 }
       },
       {
-        p: {
-         type: 'person',
-         person-name: [
-           { type: 'person-name', value: 'Bob' }
+        "p": {
+         "type": { "root": "entity", "label": "person" },
+         "person-name": [
+            { "value":"Bob", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
          ],
-         age: [ ]
+         "age": [ ]
        },
-       employment-count: { value: 0 }
+       "employment-count": { "value":0 }
       }]
       """
 
 
-  Feature: a project can be relabeled
+  Scenario: fetch subqueries can be nested and use bindings from any parent
+    Given for each session, transaction closes
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      match
+      $p2 isa person, has person-name "Bob";
+      $c1 isa company, has name "Vaticle";
+      insert
+      (employee: $p2, employer: $c1) isa employment, has ref 6;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name "Alice";
+      fetch
+      $p: age;
+      alice-employers: {
+        match
+        (employee: $p, employer: $c) isa employment;
+        fetch
+        $c as company: name;
+        alice-employment-rel: {
+          match
+          $r (employee: $p, employer: $c) isa employment;
+          fetch
+          $r: ref;
+        };
+      };
+      """
+    Then fetch answers are
+      """
+      [{
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "age": [
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
+          ]
+        },
+        "alice-employers": [
+          {
+            "company": {
+              "type": { "root": "entity", "label": "company" },
+              "name": [
+                { "value": "Vaticle", "value_type": "string", "type": { "root": "attribute", "label": "company-name" } }
+              ]
+            },
+            "alice-employment-rel": [
+              {
+                "r": {
+                  "ref": [
+                    { "value": 4, "value_type": "long", "type": { "root": "attribute", "label": "ref" } }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }]
+      """
+
+
+  Scenario: a projection can be relabeled
     When get answers of typeql fetch
       """
       match
@@ -295,16 +371,37 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        person: { label: 'person' }
+        "person": { "root": "entity", "label": "person" }
       }]
       """
 
 
-  Feature: an attribute projection can be relabeled
+  Scenario: labels can have spaces
     When get answers of typeql fetch
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name "Alice";
+      fetch
+      $p as "person Alice": age as "her age";
+      """
+    Then fetch answers are
+      """
+      [{
+        "person Alice": {
+          "type": { "root": "entity", "label": "person" },
+          "her age": [
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
+          ]
+        }
+      }]
+      """
+
+
+  Scenario: an attribute projection can be relabeled
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name as name, age;
       sort $n;
@@ -312,52 +409,107 @@ Feature: TypeQL Fetch Query
     Then fetch answers are
       """
       [{
-        p: {
-          type: 'person',
-          name: [
-            { type: 'person-name', value: 'Alice' }
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "name": [
+            { "value": "Alice", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } },
+            { "value": "Allie", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
           ],
-          age: [
-            { type: 'age', value: 10 }
+          "age": [
+            { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
           ]
+        }
       },
-        p: {
-          type: 'person',
-          name: [
-            { type: 'person-name', value: 'Bob' }
+      {
+        "p": {
+          "type": { "root": "entity", "label": "person" },
+          "name": [
+            { "value": "Bob", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
           ],
-          age: [ ]
+          "age": [ ]
+        }
       }]
       """
 
 
-  Feature: an attribute projection with an invalid type throws
-    When get answers of typeql fetch; throws exception
+  Scenario: a fetch with zero projections throws
+    When typeql fetch; throws exception
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n;
+      fetch;
+      """
+
+
+  Scenario: a variable projection that can contain entities or relations throws
+    When typeql fetch; throws exception
+      """
+      match
+      $x isa entity;
+      fetch
+      $x;
+      """
+
+
+  Scenario: an attribute projection with an invalid attribute type throws
+    When typeql fetch; throws exception
+      """
+      match
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: type;
       sort $n;
       """
-
-
-  Feature: an attribute projection with an invalid relabel throws
-    When get answers of typeql fetch; throws exception
+    When typeql fetch; throws exception
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
-      $p: person-name as type;
+      $p: person;
       sort $n;
       """
 
 
-  Feature: a fetch subquery cannot be an insert, match-get, match-group, or match-group-aggregate
-    When get answers of typeql fetch; throws exception
+  Scenario: an attribute projection from a type throws
+    When typeql fetch; throws exception
+      """
+      match
+      $p type person;
+      fetch
+      $p: name;
+      """
+
+
+  Scenario: fetching a variable that is not present in the match throws
+    When typeql fetch; throws exception
+      """
+      match
+      $p isa person, has person-name $n;
+      fetch
+      $x: type;
+      """
+
+
+  Scenario: a subquery that is not connected to the match throws
+    When typeql fetch; throws exception
+      """
+      match
+      $p isa person, has person-name $n;
+      fetch
+      all-employments-count: {
+        match
+        $r isa employment;
+        get $r;
+        count;
+      };
+      """
+
+
+  Scenario: a fetch subquery cannot be an insert, match-get, match-group, or match-group-aggregate
+    When typeql fetch; throws exception
     """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name, age;
       inserted: {
@@ -365,10 +517,10 @@ Feature: TypeQL Fetch Query
       };
       sort $n;
       """
-    When get answers of typeql fetch; throws exception
+    When typeql fetch; throws exception
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name, age;
       ages: {
@@ -378,10 +530,10 @@ Feature: TypeQL Fetch Query
       };
       sort $n;
       """
-    When get answers of typeql fetch; throws exception
+    When typeql fetch; throws exception
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name, age;
       groups: {
@@ -392,10 +544,10 @@ Feature: TypeQL Fetch Query
       };
       sort $n;
       """
-    When get answers of typeql fetch; throws exception
+    When typeql fetch; throws exception
       """
       match
-      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      $p isa person, has person-name $n; { $n == "Alice"; } or { $n == "Bob"; };
       fetch
       $p: person-name, age;
       group-counts: {

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -46,12 +46,16 @@ Feature: TypeQL Fetch Query
       employment sub relation,
         relates employee,
         relates employer,
-        owns ref @key;
+        owns ref @key,
+        owns start-date,
+        owns end-date;
       name sub attribute, abstract, value string;
       person-name sub name;
       company-name sub name;
       age sub attribute, value long;
       ref sub attribute, value long;
+      start-date sub attribute, value datetime;
+      end-date sub attribute, value datetime;
       """
     Given transaction commits
 
@@ -65,7 +69,7 @@ Feature: TypeQL Fetch Query
       $p2 isa person, has person-name "Bob", has ref 1;
       $c1 isa company, has company-name "Vaticle", has ref 2;
       $f1 (friend: $p1, friend: $p2) isa friendship, has ref 3;
-      $e1 (employee: $p1, employer: $c1) isa employment, has ref 4;
+      $e1 (employee: $p1, employer: $c1) isa employment, has ref 4, has start-date 2020-01-01T13:13:13.999, has end-date 2021-01-01;
       """
     Given transaction commits
 
@@ -142,7 +146,23 @@ Feature: TypeQL Fetch Query
         "a": { "value":"Vaticle", "value_type": "string", "type": { "root": "attribute", "label": "company-name" } }
       }]
       """
-
+    When get answers of typeql fetch
+      """
+      match
+      $a isa $t; $t value datetime;
+      fetch
+      $a;
+      sort $a;
+      """
+    Then fetch answers are
+      """
+      [{
+        "a": { "value": "2020-01-01T13:13:13.999", "value_type": "datetime", "type": { "root": "attribute", "label": "start-date" } }
+      },
+      {
+        "a": { "value": "2021-01-01T00:00:00.000", "value_type": "datetime", "type": { "root": "attribute", "label": "end-date" } }
+      }]
+      """
 
   Scenario: a value can be fetched
     When get answers of typeql fetch

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -309,7 +309,7 @@ Feature: TypeQL Fetch Query
             { "value": 10, "value_type": "long", "type": { "root": "attribute", "label": "age" } }
           ]
         },
-        "employment-count": { "value":1 }
+        "employment-count": { "value": 1, "value_type": "long" }
       },
       {
         "p": {
@@ -317,9 +317,9 @@ Feature: TypeQL Fetch Query
          "person-name": [
             { "value":"Bob", "value_type": "string", "type": { "root": "attribute", "label": "person-name" } }
          ],
-         "age": [ ]
+         "age": []
        },
-       "employment-count": { "value":0 }
+       "employment-count": { "value": 0, "value_type": "long" }
       }]
       """
 
@@ -379,7 +379,8 @@ Feature: TypeQL Fetch Query
                 "r": {
                   "ref": [
                     { "value": 4, "value_type": "long", "type": { "root": "attribute", "label": "ref" } }
-                  ]
+                  ],
+                  "type": { "root": "relation", "label": "employment" }
                 }
               }
             ]

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -296,7 +296,7 @@ Feature: TypeQL Fetch Query
 
 
   Scenario: fetch subqueries can be nested and use bindings from any parent
-    Given for each session, transaction closes
+    Given session transaction closes
     Given session opens transaction of type: write
     Given typeql insert
       """

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -100,6 +100,7 @@ Feature: TypeQL Fetch Query
       }]
       """
 
+
   # TODO: remove this scenario when we finish deprecating 'thing' type
   Scenario: root thing type can be fetched
     When get answers of typeql fetch
@@ -226,6 +227,16 @@ Feature: TypeQL Fetch Query
           ]
         }
       }]
+      """
+
+
+  Scenario: attributes that can never be owned by any matching type of a variable throw exceptions
+    When typeql fetch; throws exception
+      """
+      match
+      $p isa person, has person-name "Alice";
+      fetch
+      $p: company-name;
       """
 
 

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -1,0 +1,267 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+#noinspection CucumberUndefinedStep
+Feature: TypeQL Fetch Query
+
+  Background: Open connection and create a simple extensible schema
+    Given typedb starts
+    Given connection opens with default authentication
+    Given connection has been opened
+    Given connection does not have any database
+    Given connection create database: typedb
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+
+    Given typeql define
+      """
+      define
+      person sub entity,
+        plays friendship:friend,
+        plays employment:employee,
+        owns person-name,
+        owns age,
+        owns ref @key;
+      company sub entity,
+        plays employment:employer,
+        owns company-name,
+        owns ref @key;
+      friendship sub relation,
+        relates friend,
+        owns ref @key;
+      employment sub relation,
+        relates employee,
+        relates employer,
+        owns ref @key;
+      name sub attribute, abstract, value string;
+      person-name sub name;
+      company-name sub name;
+      age sub attribute, value long;
+      ref sub attribute, value long;
+      """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert
+      $p1 isa person, has person-name "Alice", has person-name "Allie", has age 10, has ref 0;
+      $p2 isa person, has person-name "Bob", ref 1;
+      $c1 isa company, has company-name "Vaticle", has ref 2
+      $f1 (friend: $p1, friend: $p2) isa friendship, has ref 3;
+      $e1 (employee: $p1, employer: $c1) isa employment, has ref 4;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+
+
+  Feature: a type can be fetched
+    When get answers of typeql fetch
+      """
+      match
+      $p type person;
+      fetch
+      $p;
+      """
+    Then fetch answers are
+      """
+      [{
+        p: { label: 'person' }
+      }]
+      """
+
+
+  Feature: an attribute can be fetched
+    When get answers of typeql fetch
+      """
+      match
+      $a isa name;
+      fetch
+      $a;
+      sort $a;
+      """
+    Then fetch answers are
+      """
+      [{
+        a: { type: 'person-name', value: 'Alice' }
+      },
+      {
+        a: { type: 'person-name', value: 'Allie' }
+      },
+      {
+        a: { type: 'person-name', value: 'Bob' }
+      },
+      {
+        a: { type: 'company-name', value: 'Vaticle' }
+      }]
+      """
+
+
+  Feature: a value can be fetched
+    When get answers of typeql fetch
+      """
+      match
+      $a isa name;
+      ?v = $a;
+      fetch
+      ?v;
+      sort $a;
+      """
+    Then fetch answers are
+      """
+      [{
+        v: { value: 'Alice' }
+      },
+      {
+        v: { value: 'Allie' }
+      },
+      {
+        v: { value: 'Bob' }
+      },
+      {
+        v: { value: 'Vaticle' }
+      }]
+      """
+
+
+  Feature: a concept's attributes can be fetched
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name $n; { $n == "Alice"; } or  { $n == "Bob"; };
+      fetch
+      $p: person-name, age;
+      sort $n;
+      """
+    Then fetch answers are
+      """
+      [{
+        p: {
+          type: 'person',
+          person-name: [
+            { type: 'person-name', value: 'Alice' },
+            { type: 'person-name', value: 'Allie' }
+          ],
+          age: [
+            { type: 'age', value: 10 }
+          ]
+      },
+        p: {
+          type: 'person',
+          person-name: [
+            { type: 'person-name', value: 'Bob' }
+          ],
+          age: [ ]
+      }]
+      """
+
+
+  Feature: a subquery can be fetched
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name $n; { $n == 'Alice'; } or { $n == 'Bob'; };
+      fetch
+      $p: person-name, age;
+      employers: {
+        match
+        (employee: $p, employer: $c) isa employment;
+        fetch
+        $c: name;
+      };
+      sort $n;
+      """
+    Then fetch answers are
+      """
+      [{
+        p: {
+          type: 'person',
+          person-name: [
+            { type: 'person-name', value: 'Alice' }
+          ],
+          age: [
+            { type: 'age', value: 10 }
+          ]
+        },
+        employers: [
+          c: {
+            type: 'company',
+            name: [ { type: 'company-name', value: 'Vaticle' }]
+          }
+        ]
+      },
+      {
+        p: {
+         type: 'person',
+         person-name: [
+           { type: 'person-name', value: 'Bob' }
+         ],
+         age: [ ]
+       },
+       employers: [ ]
+      }]
+      """
+
+
+  Feature: a project can be relabeled
+    When get answers of typeql fetch
+      """
+      match
+      $p type person;
+      fetch
+      $p as person;
+      """
+    Then fetch answers are
+      """
+      [{
+        person: { label: 'person' }
+      }]
+      """
+
+
+  Feature: an attribute projection can be relabeled
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name $n;
+      fetch
+      $p: person-name as name, age;
+      sort $n;
+      """
+    Then fetch answers are
+      """
+      [{
+        p: {
+          type: 'person',
+          name: [
+            { type: 'person-name', value: 'Alice' }
+          ],
+          age: [
+            { type: 'age', value: 10 }
+          ]
+      },
+        p: {
+          type: 'person',
+          name: [
+            { type: 'person-name', value: 'Bob' }
+          ],
+          age: [ ]
+      }]
+      """

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -490,6 +490,7 @@ Feature: TypeQL Fetch Query
       $p: type;
       sort $n;
       """
+    Given session opens transaction of type: read
     When typeql fetch; throws exception
       """
       match
@@ -547,6 +548,7 @@ Feature: TypeQL Fetch Query
       };
       sort $n;
       """
+    Given session opens transaction of type: read
     When typeql fetch; throws exception
       """
       match
@@ -560,6 +562,7 @@ Feature: TypeQL Fetch Query
       };
       sort $n;
       """
+    Given session opens transaction of type: read
     When typeql fetch; throws exception
       """
       match
@@ -574,6 +577,7 @@ Feature: TypeQL Fetch Query
       };
       sort $n;
       """
+    Given session opens transaction of type: read
     When typeql fetch; throws exception
       """
       match

--- a/query/language/get.feature
+++ b/query/language/get.feature
@@ -16,7 +16,7 @@
 #
 
 #noinspection CucumberUndefinedStep
-Feature: TypeQL Get Clause
+Feature: TypeQL Get Query
 
   Background: Open connection and create a simple extensible schema
     Given typedb starts

--- a/query/language/get.feature
+++ b/query/language/get.feature
@@ -352,7 +352,7 @@ Feature: TypeQL Get Query
       get;
       <agg_type> $y;
       """
-    Then aggregate answer is not a number
+    Then aggregate answer is empty
 
     Examples:
       | agg_type |
@@ -476,7 +476,7 @@ Feature: TypeQL Get Query
       get;
       sum $y;
       """
-    Then aggregate answer is not a number
+    Then aggregate answer is empty
 
 
   #########
@@ -726,3 +726,36 @@ Feature: TypeQL Get Query
       | owner              | value |
       | value:string:Alice |  10   |
       | value:string:Bob   |   5   |
+
+
+  Scenario: Grouped standard deviation aggregate of one value returns an empty group value
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      income sub attribute, value double;
+      person owns income;
+      """
+    Given transaction commits
+    Given connection close all sessions
+
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+    """
+    insert
+    $x isa person, has income 100.0, has ref 0;
+    """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get group aggregate
+      """
+      match $x isa person, has income $y;
+      get $x, $y;
+      group $x;
+      std $y;
+      """
+    Then group aggregate answer value is empty

--- a/query/language/get.feature
+++ b/query/language/get.feature
@@ -73,7 +73,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $z isa person, has name $x, has age $y;
@@ -85,7 +85,7 @@ Feature: TypeQL Get Clause
 
 
   Scenario: when a 'get' has unbound variables, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa person; get $y;
       """
@@ -101,7 +101,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $z isa person, has name $x, has age $y;
@@ -112,683 +112,6 @@ Feature: TypeQL Get Clause
       | z         | x              | b                |
       | key:ref:0 | attr:name:Lisa | value:long:2001  |
 
-
-  ########
-  # SORT #
-  ########
-
-  Scenario Outline: the answers of a match can be sorted by an attribute of type '<type>'
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-      """
-      define
-      <attr> sub attribute, value <type>, owns ref @key;
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
-      """
-      insert
-      $a <val1> isa <attr>, has ref 0;
-      $b <val2> isa <attr>, has ref 1;
-      $c <val3> isa <attr>, has ref 2;
-      $d <val4> isa <attr>, has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa <attr>;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:3 |
-      | key:ref:1 |
-      | key:ref:2 |
-      | key:ref:0 |
-
-    Examples:
-      | attr          | type     | val4       | val2             | val3             | val1       |
-      | colour        | string   | "blue"     | "green"          | "red"            | "yellow"   |
-      | score         | long     | -38        | -4               | 18               | 152        |
-      | correlation   | double   | -29.7      | -0.9             | 0.01             | 100.0      |
-      | date-of-birth | datetime | 1970-01-01 | 1999-12-31T23:00 | 1999-12-31T23:01 | 2020-02-29 |
-
-
-  Scenario: sort order can be ascending or descending
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y asc;
-      """
-    Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | attr:name:Brenda     |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
-      | key:ref:1 | attr:name:Jemima     |
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y desc;
-      """
-    Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:1 | attr:name:Jemima     |
-      | key:ref:0 | attr:name:Gary       |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:3 | attr:name:Brenda     |
-
-
-  Scenario: the default sort order is ascending
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y;
-      """
-    Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | attr:name:Brenda     |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
-      | key:ref:1 | attr:name:Jemima     |
-
-
-  Scenario: Sorting on value variables is supported
-    Given typeql insert
-      """
-      insert
-      $a isa person, has age 18, has ref 0;
-      $b isa person, has age 14, has ref 1;
-      $c isa person, has age 20, has ref 2;
-      $d isa person, has age 16, has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match
-        $x isa person, has age $a;
-        ?to20 = 20 - $a;
-      sort
-        ?to20 desc;
-      """
-    Then order of answer concepts is
-      | x         | to20         |
-      | key:ref:1 | value:long:6 |
-      | key:ref:3 | value:long:4 |
-      | key:ref:0 | value:long:2 |
-      | key:ref:2 | value:long:0 |
-
-
-  Scenario: multiple sort variables may be used to sort ascending
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0, has age 15;
-      $b isa person, has name "Gary", has ref 1, has age 5;
-      $c isa person, has name "Gary", has ref 2, has age 25;
-      $d isa person, has name "Brenda", has ref 3, has age 12;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y, has ref $r, has age $a;
-      sort $y, $a, $r asc;
-      """
-    Then order of answer concepts is
-     | y                 |  a           | x         |
-     | attr:name:Brenda  | attr:age:12  | key:ref:3 |
-     | attr:name:Gary    | attr:age:5   | key:ref:1 |
-     | attr:name:Gary    | attr:age:15  | key:ref:0 |
-     | attr:name:Gary    | attr:age:25  | key:ref:2 |
-
-
-  Scenario: multiple sort variables may be used to sort ascending or descending
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0, has age 15;
-      $b isa person, has name "Gary", has ref 1, has age 5;
-      $c isa person, has name "Gary", has ref 2, has age 25;
-      $d isa person, has name "Brenda", has ref 3, has age 12;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y, has ref $r, has age $a;
-      sort $y asc, $a desc, $r desc;
-      """
-    Then order of answer concepts is
-      | y                 |  a           | x         |
-      | attr:name:Brenda  | attr:age:12  | key:ref:3 |
-      | attr:name:Gary    | attr:age:25  | key:ref:2 |
-      | attr:name:Gary    | attr:age:15  | key:ref:0 |
-      | attr:name:Gary    | attr:age:5   | key:ref:1 |
-
-
-  Scenario: a sorted result set can be limited to a specific size
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y asc;
-      limit 3;
-      """
-    Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | attr:name:Brenda     |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
-
-
-  Scenario: sorted results can be retrieved starting from a specific offset
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y asc;
-      offset 2;
-      """
-    Then order of answer concepts is
-      | x         | y                 |
-      | key:ref:0 | attr:name:Gary    |
-      | key:ref:1 | attr:name:Jemima  |
-
-
-  Scenario: 'offset' and 'limit' can be used together to restrict the answer set
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y asc;
-      offset 1;
-      limit 2;
-      """
-    Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
-
-
-  Scenario: when the answer size is limited to 0, an empty answer set is returned
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y asc;
-      limit 0;
-      """
-    Then answer size is: 0
-
-
-  Scenario: when the offset is outside the bounds of the matched answer set, an empty answer set is returned
-    Given typeql insert
-      """
-      insert
-      $a isa person, has name "Gary", has ref 0;
-      $b isa person, has name "Jemima", has ref 1;
-      $c isa person, has name "Frederick", has ref 2;
-      $d isa person, has name "Brenda", has ref 3;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has name $y;
-      sort $y asc;
-      offset 5;
-      """
-    Then answer size is: 0
-
-
-  Scenario: string sorting is case-sensitive
-    Given typeql insert
-      """
-      insert
-      $a "Bond" isa name;
-      $b "James Bond" isa name;
-      $c "007" isa name;
-      $d "agent" isa name;
-      $e "secret agent" isa name;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    Then get answers of typeql match
-      """
-      match $x isa name;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x                       |
-      | attr:name:007           |
-      | attr:name:Bond          |
-      | attr:name:James Bond    |
-      | attr:name:agent         |
-      | attr:name:secret agent  |
-
-
-  Scenario: sort is able to correctly handle duplicates in the value set
-    Given typeql insert
-      """
-      insert
-      $a isa person, has age 2, has ref 0;
-      $b isa person, has age 6, has ref 1;
-      $c isa person, has age 12, has ref 2;
-      $d isa person, has age 6, has ref 3;
-      $e isa person, has age 2, has ref 4;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    When get answers of typeql match
-      """
-      match $x isa person, has age $y;
-      sort $y asc;
-      limit 2;
-      """
-    Then uniquely identify answer concepts
-      | x         | y           |
-      | key:ref:0 | attr:age:2  |
-      | key:ref:4 | attr:age:2  |
-    When get answers of typeql match
-      """
-      match $x isa person, has age $y;
-      sort $y asc;
-      offset 2;
-      limit 2;
-      """
-    Then uniquely identify answer concepts
-      | x         | y           |
-      | key:ref:1 | attr:age:6  |
-      | key:ref:3 | attr:age:6  |
-
-
-  Scenario: when sorting by a variable not contained in the answer set, an error is thrown
-    Given typeql insert
-      """
-      insert
-      $a isa person, has age 2, has ref 0;
-      $b isa person, has age 6, has ref 1;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    Then typeql match; throws exception
-      """
-      match
-        $x isa person, has age $y;
-      get $x;
-      sort $y asc;
-      limit 2;
-      """
-
-  Scenario: when sorting by a variable that may contain incomparable values, an error is thrown
-    Given typeql insert
-      """
-      insert
-      $a isa person, has age 2, has name "Abby", has ref 0;
-      $b isa person, has age 6, has name "Bobby", has ref 1;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    Then typeql match; throws exception
-      """
-      match
-        $x isa person, attribute $a;
-      sort $a asc;
-      """
-
-
-  Scenario Outline: sorting and query predicates agree for type '<type>'
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-      """
-      define
-      <attr> sub attribute, value <type>, owns ref @key;
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
-      """
-      insert
-      $a <pivot> isa <attr>, has ref 0;
-      $b <lesser> isa <attr>, has ref 1;
-      $c <greater> isa <attr>, has ref 2;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-
-    # ascending
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x < <pivot>;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:1 |
-
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x <= <pivot>;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:1 |
-      | key:ref:0 |
-
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x > <pivot>;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:2 |
-
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x >= <pivot>;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:0 |
-      | key:ref:2 |
-
-    # descending
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x < <pivot>;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:1 |
-
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x <= <pivot>;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:0 |
-      | key:ref:1 |
-
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x > <pivot>;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:2 |
-
-    When get answers of typeql match
-      """
-      match $x isa <attr>; $x >= <pivot>;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:2 |
-      | key:ref:0 |
-
-    Examples:
-      | attr          | type     | pivot      | lesser       | greater          |
-      | colour        | string   | "green"    | "blue"       | "red"            |
-      | score         | long     | -4         | -38          | 18               |
-      | correlation   | double   | -0.9       | -1.2         | 0.01             |
-      | date-of-birth | datetime | 1970-02-01 |  1970-01-01  | 1999-12-31T23:01 |
-
-
-  Scenario Outline: sorting and query predicates produce order ignoring types
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-      """
-      define
-      <firstAttr> sub attribute, value <firstType>, owns ref @key;
-      <secondAttr> sub attribute, value <secondType>, owns ref @key;
-      <thirdAttr> sub attribute, value <thirdType>, owns ref @key;
-      <fourthAttr> sub attribute, value <fourthType>, owns ref @key;
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
-      """
-      insert
-      $first1 <firstValue1> isa <firstAttr>, has ref 0;
-      $first2 <firstValue2> isa <firstAttr>, has ref 1;
-      $second <secondValue> isa <secondAttr>, has ref 2;
-      $third <thirdValue> isa <thirdAttr>, has ref 3;
-      $fourth <fourthValuePivot> isa <fourthAttr>, has ref 4;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-
-    # ascending
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref;
-      get $x;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:2 |
-      | key:ref:1 |
-      | key:ref:4 |
-      | key:ref:0 |
-      | key:ref:3 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x < <fourthValuePivot>;
-      get $x;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:2 |
-      | key:ref:1 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x <= <fourthValuePivot>;
-      get $x;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:2 |
-      | key:ref:1 |
-      | key:ref:4 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x > <fourthValuePivot>;
-      get $x;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:0 |
-      | key:ref:3 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x >= <fourthValuePivot>;
-      get $x;
-      sort $x asc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:4 |
-      | key:ref:0 |
-      | key:ref:3 |
-
-    # descending
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref;
-      get $x;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:3 |
-      | key:ref:0 |
-      | key:ref:4 |
-      | key:ref:1 |
-      | key:ref:2 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x < <fourthValuePivot>;
-      get $x;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:1 |
-      | key:ref:2 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x <= <fourthValuePivot>;
-      get $x;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:4 |
-      | key:ref:1 |
-      | key:ref:2 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x > <fourthValuePivot>;
-      get $x;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:3 |
-      | key:ref:0 |
-
-    When get answers of typeql match
-      """
-      match $x isa $t; $t owns ref; $x >= <fourthValuePivot>;
-      get $x;
-      sort $x desc;
-      """
-    Then order of answer concepts is
-      | x         |
-      | key:ref:3 |
-      | key:ref:0 |
-      | key:ref:4 |
-
-    Examples:
-      # NOTE: fourthValuePivot is expected to be the middle of the sort order (pivot)
-      | firstAttr   | firstType | firstValue1 | firstValue2 | secondAttr | secondType | secondValue | thirdAttr | thirdType | thirdValue | fourthAttr | fourthType | fourthValuePivot |
-      | colour      | string    | "green"     | "blue"      | name       | string     | "alice"     | shape     | string    | "square"   | street     | string     | "carnaby"        |
-      | score       | long      | 4           | -38         | quantity   | long       | -50         | area      | long      | 100        | length     | long       | 0                |
-      | correlation | double    | 4.1         | -38.999     | quantity   | double     | -101.4      | area      | double    | 110.0555   | length     | double     | 0.5              |
-      # mixed double-long data
-      | score       | long      | 4           | -38         | quantity   | double     | -55.123     | area      | long      | 100        | length     | double     | 0.5              |
-      | dob         | datetime  | 2970-01-01   | 1970-02-01 | start-date | datetime   | 1970-01-01  | end-date  | datetime  | 3100-11-20 | last-date  | datetime   | 2000-08-03       |
 
   #############
   # AGGREGATE #
@@ -806,7 +129,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa person;
@@ -814,7 +137,7 @@ Feature: TypeQL Get Clause
         $f isa friendship;
       """
     Then answer size is: 9
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match
         $x isa person;
@@ -823,7 +146,7 @@ Feature: TypeQL Get Clause
       count;
       """
     Then aggregate value is: 9
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa person;
@@ -831,7 +154,7 @@ Feature: TypeQL Get Clause
         $f (friend: $x) isa friendship;
       """
     Then answer size is: 6
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match
         $x isa person;
@@ -843,7 +166,7 @@ Feature: TypeQL Get Clause
 
 
   Scenario: the 'count' of an empty answer set is zero
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has name "Voldemort";
       count;
@@ -876,7 +199,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has <attr> $y;
       <agg_type> $y;
@@ -922,7 +245,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has weight $y;
       std $y;
@@ -942,13 +265,13 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has name $y, has age $z;
       sum $z;
       """
     Then aggregate value is: 65
-    Then get answer of typeql match aggregate
+    Then get answer of typeql get aggregate
       """
       match $x isa person, has name $y, has age $z;
       get $y, $z;
@@ -967,7 +290,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has age $y;
       <agg_type> $y;
@@ -992,7 +315,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has age $y;
       median $y;
@@ -1013,7 +336,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has income $y;
       <agg_type> $y;
@@ -1031,7 +354,7 @@ Feature: TypeQL Get Clause
 
 
   Scenario Outline: an error is thrown when getting the '<agg_type>' of an undefined variable in an aggregate query
-    Then typeql match aggregate; throws exception
+    Then typeql get aggregate; throws exception
       """
       match $x isa person;
       <agg_type> $y;
@@ -1055,7 +378,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match aggregate; throws exception
+    Then typeql get aggregate; throws exception
       """
       match $x isa person;
       min $x;
@@ -1085,7 +408,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match aggregate; throws exception
+    Then typeql get aggregate; throws exception
       """
       match $x isa person, has <attr> $y;
       <agg_type> $y;
@@ -1124,7 +447,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match aggregate; throws exception
+    Then typeql get aggregate; throws exception
       """
       match $x isa person, has attribute $y;
       sum $y;
@@ -1132,7 +455,7 @@ Feature: TypeQL Get Clause
 
 
   Scenario: when taking the sum of an empty set, even if any matches would definitely be strings, no error is thrown and an empty answer is returned
-    When get answer of typeql match aggregate
+    When get answer of typeql get aggregate
       """
       match $x isa person, has name $y;
       sum $y;
@@ -1157,7 +480,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match ($x, $y) isa friendship;
       """
@@ -1175,7 +498,7 @@ Feature: TypeQL Get Clause
       | key:ref:3 | key:ref:0 |
       | key:ref:3 | key:ref:1 |
       | key:ref:3 | key:ref:2 |
-    When get answers of typeql match group
+    When get answers of typeql get group
       """
       match ($x, $y) isa friendship;
       group $x;
@@ -1207,7 +530,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match group
+    When get answers of typeql get group
       """
       match
        $x isa person, has ref $r;
@@ -1233,7 +556,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match group; throws exception
+    Then typeql get group; throws exception
       """
       match ($x, $y) isa friendship;
       get $x;
@@ -1259,11 +582,11 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
-    When get answers of typeql match group aggregate
+    When get answers of typeql get group aggregate
       """
       match ($x, $y) isa friendship;
       group $x;
@@ -1292,7 +615,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $x isa company;
@@ -1310,7 +633,7 @@ Feature: TypeQL Get Clause
       | key:ref:0 | key:ref:3 | key:ref:4 |
       | key:ref:1 | key:ref:4 | key:ref:2 |
       | key:ref:1 | key:ref:4 | key:ref:3 |
-    Then get answers of typeql match group aggregate
+    Then get answers of typeql get group aggregate
       """
       match
         $x isa company;
@@ -1344,7 +667,7 @@ Feature: TypeQL Get Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match group aggregate
+    When get answers of typeql get group aggregate
       """
       match
         $x isa company;
@@ -1371,7 +694,7 @@ Feature: TypeQL Get Clause
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match group aggregate
+    When get answers of typeql get group aggregate
       """
       match
        $p isa person, has name $name, has age $a;

--- a/query/language/get.feature
+++ b/query/language/get.feature
@@ -135,6 +135,7 @@ Feature: TypeQL Get Query
         $x isa person;
         $y isa name;
         $f isa friendship;
+      get;
       """
     Then answer size is: 9
     When get answer of typeql get aggregate
@@ -143,6 +144,7 @@ Feature: TypeQL Get Query
         $x isa person;
         $y isa name;
         $f isa friendship;
+      get;
       count;
       """
     Then aggregate value is: 9
@@ -152,6 +154,7 @@ Feature: TypeQL Get Query
         $x isa person;
         $y isa name;
         $f (friend: $x) isa friendship;
+      get;
       """
     Then answer size is: 6
     When get answer of typeql get aggregate
@@ -160,6 +163,7 @@ Feature: TypeQL Get Query
         $x isa person;
         $y isa name;
         $f (friend: $x) isa friendship;
+      get;
       count;
       """
     Then aggregate value is: 6
@@ -169,6 +173,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has name "Voldemort";
+      get;
       count;
       """
     Then aggregate value is: 0
@@ -202,6 +207,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has <attr> $y;
+      get;
       <agg_type> $y;
       """
     Then aggregate value is: <agg_val>
@@ -248,6 +254,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has weight $y;
+      get;
       std $y;
       """
     # Note: This is the sample standard deviation, NOT the population standard deviation
@@ -268,6 +275,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has name $y, has age $z;
+      get;
       sum $z;
       """
     Then aggregate value is: 65
@@ -293,6 +301,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has age $y;
+      get;
       <agg_type> $y;
       """
     Then aggregate value is: <agg_val>
@@ -318,6 +327,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has age $y;
+      get;
       median $y;
       """
     Then aggregate value is: 36.5
@@ -339,6 +349,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has income $y;
+      get;
       <agg_type> $y;
       """
     Then aggregate answer is not a number
@@ -357,6 +368,7 @@ Feature: TypeQL Get Query
     Then typeql get aggregate; throws exception
       """
       match $x isa person;
+      get;
       <agg_type> $y;
       """
 
@@ -381,6 +393,7 @@ Feature: TypeQL Get Query
     Then typeql get aggregate; throws exception
       """
       match $x isa person;
+      get;
       min $x;
       """
 
@@ -411,6 +424,7 @@ Feature: TypeQL Get Query
     Then typeql get aggregate; throws exception
       """
       match $x isa person, has <attr> $y;
+      get;
       <agg_type> $y;
       """
 
@@ -450,6 +464,7 @@ Feature: TypeQL Get Query
     Then typeql get aggregate; throws exception
       """
       match $x isa person, has attribute $y;
+      get;
       sum $y;
       """
 
@@ -458,6 +473,7 @@ Feature: TypeQL Get Query
     When get answer of typeql get aggregate
       """
       match $x isa person, has name $y;
+      get;
       sum $y;
       """
     Then aggregate answer is not a number
@@ -482,7 +498,7 @@ Feature: TypeQL Get Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match ($x, $y) isa friendship;
+      match ($x, $y) isa friendship; get;
       """
     Then uniquely identify answer concepts
       | x         | y         |
@@ -501,6 +517,7 @@ Feature: TypeQL Get Query
     When get answers of typeql get group
       """
       match ($x, $y) isa friendship;
+      get;
       group $x;
       """
     Then answer groups are
@@ -584,11 +601,12 @@ Feature: TypeQL Get Query
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     When get answers of typeql get group aggregate
       """
       match ($x, $y) isa friendship;
+      get;
       group $x;
       count;
       """
@@ -673,6 +691,7 @@ Feature: TypeQL Get Query
         $x isa company;
         $y isa person, has age $z;
         ($x, $y) isa employment;
+      get;
       group $x;
       max $z;
       """

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -471,6 +471,7 @@ Parker", has ref 0;
 """
 match $p has name "Peter
 Parker";
+get;
 """
     Then uniquely identify answer concepts
       | p         |

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -81,7 +81,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -100,7 +100,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -121,21 +121,21 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has name "Bond";
+      match $x has name "Bond"; get;
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
     When get answers of typeql get
       """
-      match $x has name "James Bond";
+      match $x has name "James Bond"; get;
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
     When get answers of typeql get
       """
-      match $x has name "Bond", has name "James Bond";
+      match $x has name "Bond", has name "James Bond"; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -159,7 +159,7 @@ Feature: TypeQL Insert Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x isa dog;
+      match $x isa dog; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -171,7 +171,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa dog;
+      match $x isa dog; get;
       """
     Then answer size is: 1
     Then typeql insert
@@ -183,7 +183,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa dog;
+      match $x isa dog; get;
       """
     Then answer size is: 2
     Then typeql insert
@@ -195,7 +195,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa dog;
+      match $x isa dog; get;
       """
     Then answer size is: 3
 
@@ -246,7 +246,7 @@ Feature: TypeQL Insert Query
   Scenario: when inserting a new thing that owns new attributes, both the thing and the attributes get created
     Given get answers of typeql get
       """
-      match $x isa thing;
+      match $x isa thing; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -258,7 +258,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa thing;
+      match $x isa thing; get;
       """
     Then uniquely identify answer concepts
       | x                     |
@@ -270,7 +270,7 @@ Feature: TypeQL Insert Query
   Scenario: when inserting a new thing that owns new attributes via a value variable, both the thing and the attributes get created
     Given get answers of typeql get
       """
-      match $x isa thing;
+      match $x isa thing; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -283,7 +283,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa thing;
+      match $x isa thing; get;
       """
     Then uniquely identify answer concepts
       | x                     |
@@ -303,7 +303,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has name "John";
+      match $x has name "John"; get;
       """
     Then answer size is: 0
 
@@ -325,7 +325,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has name "Kyle";
+      match $x has name "Kyle"; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -386,7 +386,7 @@ Feature: TypeQL Insert Query
     Given session opens transaction of type: write
     When get answers of typeql get
       """
-      match $p isa dog;
+      match $p isa dog; get;
       """
     Then answer size is: 5
     When typeql insert
@@ -401,7 +401,7 @@ Feature: TypeQL Insert Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $p isa dog;
+      match $p isa dog; get;
       """
     Then answer size is: 10
 
@@ -491,7 +491,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $p has name "Spiderman";
+      match $p has name "Spiderman"; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -506,7 +506,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $p has name "Spiderman";
+      match $p has name "Spiderman"; get;
       """
     Then uniquely identify answer concepts
       | p         |
@@ -524,7 +524,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $p has name "Spiderman";
+      match $p has name "Spiderman"; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -539,7 +539,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $p has name "Spiderman";
+      match $p has name "Spiderman"; get;
       """
     Then uniquely identify answer concepts
       | p         |
@@ -571,7 +571,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $c has hex-value "#FF0000";
+      match $c has hex-value "#FF0000"; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -586,7 +586,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $c has hex-value "#FF0000";
+      match $c has hex-value "#FF0000"; get;
       """
     Then uniquely identify answer concepts
       | c                |
@@ -618,7 +618,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $c has hex-value "#FF0000";
+      match $c has hex-value "#FF0000"; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -633,7 +633,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $c has hex-value "#FF0000";
+      match $c has hex-value "#FF0000"; get;
       """
     Then uniquely identify answer concepts
       | c                |
@@ -673,7 +673,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $td isa tenure-days;
+      match $td isa tenure-days; get;
       """
     Then answer size is: 0
     When typeql insert
@@ -725,7 +725,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $p has age 32;
+      match $p has age 32; get;
       """
     Given uniquely identify answer concepts
       | p         |
@@ -742,7 +742,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $p has age 32;
+      match $p has age 32; get;
       """
     Then uniquely identify answer concepts
       | p         |
@@ -765,7 +765,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (employee: $p) isa employment;
+      match $r (employee: $p) isa employment; get;
       """
     Then uniquely identify answer concepts
       | p         | r         |
@@ -806,7 +806,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (place: $addr) isa residence, has is-permanent $perm;
+      match $r (place: $addr) isa residence, has is-permanent $perm; get;
       """
     Then uniquely identify answer concepts
       | r         | addr                                | perm                    |
@@ -866,7 +866,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (employer: $c, employee: $p) isa employment;
+      match $r (employer: $c, employee: $p) isa employment; get;
       """
     Then uniquely identify answer concepts
       | p         | c         | r         |
@@ -898,7 +898,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (employer: $c, employee: $p) isa employment;
+      match $r (employer: $c, employee: $p) isa employment; get;
       """
     Then uniquely identify answer concepts
       | p         | c         | r         |
@@ -927,7 +927,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (employee: $p, employee: $p) isa employment;
+      match $r (employee: $p, employee: $p) isa employment; get;
       """
     Then uniquely identify answer concepts
       | p         | r         |
@@ -1018,7 +1018,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match (member: $p) isa gym-membership; get $p;
+      match (member: $p) isa gym-membership; get $p; get;
       """
     Then typeql insert
       """
@@ -1032,7 +1032,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match (member: $p) isa gym-membership; get $p;
+      match (member: $p) isa gym-membership; get $p; get;
       """
     Then uniquely identify answer concepts
       | p         |
@@ -1063,7 +1063,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x <value> isa <attr>;
+      match $x <value> isa <attr>; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -1075,7 +1075,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x <value> isa <attr>;
+      match $x <value> isa <attr>; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1105,7 +1105,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x <value> isa <attr>;
+      match $x <value> isa <attr>; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -1118,7 +1118,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x <value> isa <attr>;
+      match $x <value> isa <attr>; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1184,7 +1184,7 @@ Parker";
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa test_date;
+      match $x isa test_date; get;
       """
     Then uniquely identify answer concepts
       | x                                  |
@@ -1202,7 +1202,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa age;
+      match $x isa age; get;
       """
     Then uniquely identify answer concepts
       | x           |
@@ -1234,7 +1234,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa length;
+      match $x isa length; get;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts
@@ -1274,7 +1274,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa length;
+      match $x isa length; get;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts
@@ -1307,7 +1307,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa length;
+      match $x isa length; get;
       """
     Then answer size is: 1
 
@@ -1337,7 +1337,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x <match> isa <attr>;
+      match $x <match> isa <attr>; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1452,7 +1452,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1591,7 +1591,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa person, has email "abc@gmail.com";
+      match $x isa person, has email "abc@gmail.com"; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1605,7 +1605,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person, has email "mnp@gmail.com", has email "xyz@gmail.com";
+      match $x isa person, has email "mnp@gmail.com", has email "xyz@gmail.com"; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1767,7 +1767,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has is-cool true;
+      match $x has is-cool true; get;
       """
     #TODO: Appears unfinished
 
@@ -1862,7 +1862,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $p isa person;
+      match $p isa person; get;
       """
     Given answer size is: 0
     When typeql insert
@@ -1877,7 +1877,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r isa season-ticket-ownership;
+      match $r isa season-ticket-ownership; get;
       """
     Then answer size is: 0
 
@@ -1898,7 +1898,7 @@ Parker";
     When session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Given uniquely identify answer concepts
       | x         |
@@ -1917,7 +1917,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1946,7 +1946,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $r (employee: $x, employer: $c) isa employment;
+      match $r (employee: $x, employer: $c) isa employment; get;
       """
     Given uniquely identify answer concepts
       | r         | x         | c         |
@@ -1965,7 +1965,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $r (employee: $x, employer: $c) isa employment;
+      match $r (employee: $x, employer: $c) isa employment; get;
       """
     Then uniquely identify answer concepts
       | r         | x         | c         |
@@ -1990,7 +1990,7 @@ Parker";
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Given uniquely identify answer concepts
       | x                |
@@ -2009,7 +2009,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -2039,7 +2039,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 1
 
@@ -2179,6 +2179,7 @@ Parker";
       match
       $x isa person;
       $r ($x) isa employment;
+      get;
       """
     Then uniquely identify answer concepts
       | x         | r         |
@@ -2262,7 +2263,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Then uniquely identify answer concepts
       | x                 |
@@ -2279,7 +2280,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     # If the name 'Ganesh' had been materialised, then it would still exist in the knowledge graph.
     Then answer size is: 0
@@ -2320,7 +2321,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa person, has score $score;
+      match $x isa person, has score $score; get;
       """
     Then uniquely identify answer concepts
       | x         | score            |
@@ -2338,7 +2339,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa score;
+      match $x isa score; get;
       """
     # The score '10.0' still exists, we never deleted it
     Then uniquely identify answer concepts
@@ -2346,7 +2347,7 @@ Parker";
       | attr:score:10.0  |
     When get answers of typeql get
       """
-      match $x isa person, has score $score;
+      match $x isa person, has score $score; get;
       """
     # But Freya's ownership of score 10.0 was never materialised and is now gone
     Then answer size is: 0
@@ -2399,7 +2400,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     Then uniquely identify answer concepts
       | x                 |
@@ -2429,12 +2430,12 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 0
     When get answers of typeql get
       """
-      match $x isa name;
+      match $x isa name; get;
       """
     # We deleted the person called 'Ganesh', but the name still exists because it was materialised on match-insert
     Then uniquely identify answer concepts
@@ -2442,7 +2443,7 @@ Parker";
       | attr:name:Ganesh  |
     When get answers of typeql get
       """
-      match (lettered-name: $x, initial: $y) isa name-initial;
+      match (lettered-name: $x, initial: $y) isa name-initial; get;
       """
     # And the inserted relation still exists too
     Then uniquely identify answer concepts
@@ -2499,7 +2500,7 @@ Parker";
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x isa employment;
+      match $x isa employment; get;
       """
     Then answer size is: 1
     # At this step we materialise the inferred employment because the material employment-contract depends on it.
@@ -2526,13 +2527,13 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa employment;
+      match $x isa employment; get;
       """
     # We deleted the rule that infers the employment, but it still exists because it was materialised on match-insert
     Then answer size is: 1
     When get answers of typeql get
       """
-      match (contracted: $x, contract: $y) isa employment-contract;
+      match (contracted: $x, contract: $y) isa employment-contract; get;
       """
     # And the inserted relation still exists too
     Then answer size is: 1
@@ -2757,12 +2758,12 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 7
     When get answers of typeql get
       """
-      match $x isa employment;
+      match $x isa employment; get;
       """
     # The original person is still unemployed.
     Then answer size is: 6
@@ -2786,7 +2787,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person, has name "Derek";
+      match $x isa person, has name "Derek"; get;
       """
     Then answer size is: 0
 
@@ -2819,7 +2820,7 @@ Parker";
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person, has name "Derek";
+      match $x isa person, has name "Derek"; get;
       """
     Then answer size is: 0
 
@@ -2839,7 +2840,7 @@ Parker";
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person, has name "Derek";
+      match $x isa person, has name "Derek"; get;
       """
     Then answer size is: 0
 

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -2174,7 +2174,7 @@ Parker";
     Given transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $x isa person;

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -205,7 +205,6 @@ Feature: TypeQL Insert Query
       """
       insert $x isa! person, has name "Harry", has ref 0;
       """
-
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -79,7 +79,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -98,7 +98,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -119,21 +119,21 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name "Bond";
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name "James Bond";
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name "Bond", has name "James Bond";
       """
@@ -157,7 +157,7 @@ Feature: TypeQL Insert Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa dog;
       """
@@ -169,7 +169,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa dog;
       """
@@ -181,7 +181,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa dog;
       """
@@ -193,7 +193,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa dog;
       """
@@ -245,7 +245,7 @@ Feature: TypeQL Insert Query
   #######################
 
   Scenario: when inserting a new thing that owns new attributes, both the thing and the attributes get created
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa thing;
       """
@@ -257,7 +257,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa thing;
       """
@@ -269,7 +269,7 @@ Feature: TypeQL Insert Query
       | attr:ref:0            |
 
   Scenario: when inserting a new thing that owns new attributes via a value variable, both the thing and the attributes get created
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa thing;
       """
@@ -282,7 +282,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa thing;
       """
@@ -302,7 +302,7 @@ Feature: TypeQL Insert Query
     Given transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name "John";
       """
@@ -324,7 +324,7 @@ Feature: TypeQL Insert Query
     Given transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name "Kyle";
       """
@@ -343,7 +343,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $p1 isa person, has age $a;
@@ -385,7 +385,7 @@ Feature: TypeQL Insert Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $p isa dog;
       """
@@ -400,7 +400,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $p isa dog;
       """
@@ -432,7 +432,7 @@ Feature: TypeQL Insert Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $p isa person, has <attr> $x; get $x;
       """
@@ -468,7 +468,7 @@ Parker", has ref 0;
 """
     Given transaction commits
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
 """
 match $p has name "Peter
 Parker";
@@ -490,7 +490,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $p has name "Spiderman";
       """
@@ -505,7 +505,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $p has name "Spiderman";
       """
@@ -523,7 +523,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $p has name "Spiderman";
       """
@@ -538,7 +538,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $p has name "Spiderman";
       """
@@ -570,7 +570,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $c has hex-value "#FF0000";
       """
@@ -585,7 +585,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $c has hex-value "#FF0000";
       """
@@ -617,7 +617,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $c has hex-value "#FF0000";
       """
@@ -632,7 +632,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $c has hex-value "#FF0000";
       """
@@ -672,7 +672,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $td isa tenure-days;
       """
@@ -687,7 +687,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r isa residence, has tenure-days $a; get $a;
       """
@@ -724,7 +724,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $p has age 32;
       """
@@ -741,7 +741,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $p has age 32;
       """
@@ -764,7 +764,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (employee: $p) isa employment;
       """
@@ -805,7 +805,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (place: $addr) isa residence, has is-permanent $perm;
       """
@@ -826,7 +826,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $r (employer: $c) isa employment;
@@ -836,7 +836,7 @@ Parker";
     Then uniquely identify answer concepts
       | cname                |
       | attr:name:Morrisons  |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $r (employee: $p) isa employment;
@@ -865,7 +865,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (employer: $c, employee: $p) isa employment;
       """
@@ -897,7 +897,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (employer: $c, employee: $p) isa employment;
       """
@@ -926,7 +926,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (employee: $p, employee: $p) isa employment;
       """
@@ -1017,7 +1017,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (member: $p) isa gym-membership; get $p;
       """
@@ -1031,14 +1031,14 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (member: $p) isa gym-membership; get $p;
       """
     Then uniquely identify answer concepts
       | p         |
       | key:ref:0 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r isa gym-membership; get $r;
       """
@@ -1062,7 +1062,7 @@ Parker";
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x <value> isa <attr>;
       """
@@ -1074,7 +1074,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x <value> isa <attr>;
       """
@@ -1104,7 +1104,7 @@ Parker";
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x <value> isa <attr>;
       """
@@ -1117,7 +1117,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x <value> isa <attr>;
       """
@@ -1183,7 +1183,7 @@ Parker";
     Given set time-zone is: America/Chicago
     Given transaction commits
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa test_date;
       """
@@ -1201,7 +1201,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa age;
       """
@@ -1233,7 +1233,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa length;
       """
@@ -1273,7 +1273,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa length;
       """
@@ -1306,7 +1306,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa length;
       """
@@ -1336,7 +1336,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x <match> isa <attr>;
       """
@@ -1451,7 +1451,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -1590,7 +1590,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has email "abc@gmail.com";
       """
@@ -1604,7 +1604,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has email "mnp@gmail.com", has email "xyz@gmail.com";
       """
@@ -1766,7 +1766,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has is-cool true;
       """
@@ -1835,7 +1835,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x has height $z;
@@ -1861,7 +1861,7 @@ Parker";
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $p isa person;
       """
@@ -1876,7 +1876,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r isa season-ticket-ownership;
       """
@@ -1897,7 +1897,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa person;
       """
@@ -1916,7 +1916,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -1945,7 +1945,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $r (employee: $x, employer: $c) isa employment;
       """
@@ -1964,7 +1964,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (employee: $x, employer: $c) isa employment;
       """
@@ -1989,7 +1989,7 @@ Parker";
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa name;
       """
@@ -2008,7 +2008,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -2038,7 +2038,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -2261,7 +2261,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -2278,7 +2278,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -2319,7 +2319,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has score $score;
       """
@@ -2337,7 +2337,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa score;
       """
@@ -2345,7 +2345,7 @@ Parker";
     Then uniquely identify answer concepts
       | x                |
       | attr:score:10.0  |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has score $score;
       """
@@ -2398,7 +2398,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -2428,12 +2428,12 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
     Then answer size is: 0
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa name;
       """
@@ -2441,7 +2441,7 @@ Parker";
     Then uniquely identify answer concepts
       | x                 |
       | attr:name:Ganesh  |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (lettered-name: $x, initial: $y) isa name-initial;
       """
@@ -2498,7 +2498,7 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa employment;
       """
@@ -2525,13 +2525,13 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa employment;
       """
     # We deleted the rule that infers the employment, but it still exists because it was materialised on match-insert
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (contracted: $x, contract: $y) isa employment-contract;
       """
@@ -2638,7 +2638,7 @@ Parker";
     # After deleting all the links to 'c', our rules no longer infer that 'd' is reachable from 'a'. But in fact we
     # materialised this reachable link when we did our match-insert, because it played a role in our road-proposal,
     # which itself plays a role in the road-construction that we explicitly inserted:
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $a isa vertex, has index "a";
@@ -2649,7 +2649,7 @@ Parker";
     # On the other hand, the fact that 'c' was reachable from 'a' was not -directly- used; although it was needed
     # in order to infer that (a,d) was reachable, it did not, itself, play a role in any relation that we materialised,
     # so it is now gone.
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $a isa vertex, has index "a";
@@ -2756,12 +2756,12 @@ Parker";
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
     Then answer size is: 7
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa employment;
       """
@@ -2785,7 +2785,7 @@ Parker";
       """
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has name "Derek";
       """
@@ -2818,7 +2818,7 @@ Parker";
       """
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has name "Derek";
       """
@@ -2838,7 +2838,7 @@ Parker";
       """
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has name "Derek";
       """

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -16,7 +16,7 @@
 #
 
 #noinspection CucumberUndefinedStep
-Feature: TypeQL Match Query
+Feature: TypeQL Match Clause
 
   Background: Open connection and create a simple extensible schema
     Given typedb starts

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -72,7 +72,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type person;
       """
@@ -91,7 +91,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub person;
       """
@@ -112,7 +112,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match writer sub $x;
       """
@@ -159,7 +159,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa $type;
@@ -195,7 +195,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub! person;
       """
@@ -215,7 +215,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match writer sub! $x;
       """
@@ -240,7 +240,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x sub $y;
@@ -254,7 +254,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'owns' matches types that own the specified attribute type
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns age;
       """
@@ -272,7 +272,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns $x;
       """
@@ -293,7 +293,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns general-name;
       """
@@ -314,7 +314,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns club-name;
       """
@@ -324,7 +324,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'owns' can be used to match attribute types that a given type owns
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match person owns $x;
       """
@@ -337,7 +337,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: directly declared 'owns' annotations are queryable
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns ref @key;
       """
@@ -347,7 +347,7 @@ Feature: TypeQL Match Query
       | label:company    |
       | label:friendship |
       | label:employment |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns $a @key;
       """
@@ -357,14 +357,14 @@ Feature: TypeQL Match Query
       | label:company    | label:ref    |
       | label:friendship | label:ref    |
       | label:employment | label:ref    |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email @unique;
       """
     Then uniquely identify answer concepts
       | x            |
       | label:person |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns $a @unique;
       """
@@ -380,7 +380,7 @@ Feature: TypeQL Match Query
       """
     Given transaction commits
     Given session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns ref @key;
       """
@@ -391,7 +391,7 @@ Feature: TypeQL Match Query
       | label:company    |
       | label:friendship |
       | label:employment |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns $a @key;
       """
@@ -402,7 +402,7 @@ Feature: TypeQL Match Query
       | label:company    | label:ref    |
       | label:friendship | label:ref    |
       | label:employment | label:ref    |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email @unique;
       """
@@ -410,7 +410,7 @@ Feature: TypeQL Match Query
       | x            |
       | label:person |
       | label:child  |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns $a @unique;
       """
@@ -442,7 +442,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa $type;
@@ -457,7 +457,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'plays' matches types that can play the specified role
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays friendship:friend;
       """
@@ -476,7 +476,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays friendship:friend;
       """
@@ -510,7 +510,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays close-friendship:close-friend;
       """
@@ -520,7 +520,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'plays' can be used to match roles that a particular type can play
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match person plays $x;
       """
@@ -553,7 +553,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa $type;
@@ -576,7 +576,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns breed @key;
       """
@@ -586,7 +586,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'key' can be used to find all attribute types that a given type owns as a key
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match person owns $x @key;
       """
@@ -606,7 +606,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns breed;
       """
@@ -617,7 +617,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'relates' matches relation types where the specified role can be played
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates employee;
       """
@@ -637,7 +637,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates close-friend as friend;
       """
@@ -656,7 +656,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates friend;
       """
@@ -666,7 +666,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: 'relates' can be used to retrieve all the roles of a relation type
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match employment relates $x;
       """
@@ -679,7 +679,7 @@ Feature: TypeQL Match Query
   # TODO we can't test like this because the IID is not a valid encoded IID -- need to rethink this test
   @ignore
   Scenario: when matching by a concept iid that doesn't exist, an empty result is returned
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x iid 0x83cb2;
@@ -705,7 +705,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa $y;
       """
@@ -748,7 +748,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa writer;
       """
@@ -783,7 +783,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa! writer;
       """
@@ -806,7 +806,7 @@ Feature: TypeQL Match Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -825,7 +825,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person;
       """
@@ -857,18 +857,18 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa! shop;
       """
-    Then templated typeql match; throws exception
+    Then templated typeql get; throws exception
       """
       match $x iid <answer.x.iid>; $x isa grocery, has address "123 street";
       """
 
 
   Scenario: match returns an empty answer if there are no matches
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has name "Anonymous Coward";
       """
@@ -876,7 +876,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: when matching by a type whose label doesn't exist, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa ganesh;
       """
@@ -884,7 +884,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: when matching by a relation type whose label doesn't exist, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match ($x, $y) isa $type; $type type jakas-relacja;
       """
@@ -892,7 +892,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: when matching a non-existent type label to a variable from a generic 'isa' query, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa $type; $type type polok;
       """
@@ -910,7 +910,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa person;
@@ -922,7 +922,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: an error is thrown when matching that a variable has a specific type, when that type is in fact a role type
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa friendship:friend;
       """
@@ -944,7 +944,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa metre-rule;
       """
@@ -971,14 +971,14 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $x isa person; $r (employee: $x) isa relation;
       """
     Then uniquely identify answer concepts
       | x         | r         |
       | key:ref:0 | key:ref:2 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $y isa company; $r (employer: $y) isa relation;
       """
@@ -1002,7 +1002,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person; $r ($x) isa relation;
       """
@@ -1025,7 +1025,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match $r ($x, $y) isa employment;
       """
@@ -1058,7 +1058,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (player: $x, player: $x) isa relation;
       """
@@ -1086,7 +1086,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r (player: $x) isa relation;
       """
@@ -1108,7 +1108,7 @@ Feature: TypeQL Match Query
       """
     Given transaction commits
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (employer: $e, $role: $x) isa employment;
       """
@@ -1139,7 +1139,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r(compared:$r) isa comparator;
       """
@@ -1170,7 +1170,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $r(compared: $v, compared:$r) isa comparator;
       """
@@ -1191,7 +1191,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match (friend: $x, friend: $x) isa friendship;
       """
@@ -1231,7 +1231,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         (sender: $a, recipient: $b) isa gift-delivery;
@@ -1240,7 +1240,7 @@ Feature: TypeQL Match Query
     Then uniquely identify answer concepts
       | a         | b         | c         |
       | key:ref:0 | key:ref:1 | key:ref:2 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         (sender: $a, recipient: $b) isa gift-delivery;
@@ -1275,7 +1275,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $r isa relation;
       """
@@ -1284,14 +1284,14 @@ Feature: TypeQL Match Query
       | key:ref:1 |
       | key:ref:2 |
       | key:ref:3 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match ($x) isa relation;
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match ($x);
       """
@@ -1301,7 +1301,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: an error is thrown when matching an entity type as if it were a role type
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match (person: $x) isa relation;
       """
@@ -1309,7 +1309,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: an error is thrown when matching an entity type as if it were a relation type
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match ($x) isa person;
       """
@@ -1317,7 +1317,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: an error is thrown when matching a non-existent type label as if it were a relation type
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match ($x) isa bottle-of-rum;
       """
@@ -1325,7 +1325,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: when matching a role type that doesn't exist, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match (rolein-rolein-rolein: $rolein) isa relation;
       """
@@ -1333,7 +1333,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: when matching a role in a relation type that doesn't have that role, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match (friend: $x) isa employment;
       """
@@ -1341,7 +1341,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: when matching a roleplayer in a relation that can't actually play that role, an error is thrown
-    When typeql match; throws exception
+    When typeql get; throws exception
       """
       match
       $x isa company;
@@ -1375,63 +1375,63 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (wife: $x, husband: $y) isa hetero-marriage;
       """
     Then answer size is: 1
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $m (wife: $x, husband: $y) isa civil-marriage;
       """
     Then session transaction is open: false
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (wife: $x, husband: $y) isa marriage;
       """
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (wife: $x, husband: $y) isa relation;
       """
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (spouse: $x, spouse: $y) isa hetero-marriage;
       """
     Then answer size is: 2
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (spouse: $x, spouse: $y) isa civil-marriage;
       """
     Then answer size is: 2
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (spouse: $x, spouse: $y) isa marriage;
       """
     Then answer size is: 4
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (spouse: $x, spouse: $y) isa relation;
       """
     Then answer size is: 4
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (role: $x, role: $y) isa hetero-marriage;
       """
     Then answer size is: 2
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (role: $x, role: $y) isa civil-marriage;
       """
     Then answer size is: 2
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (role: $x, role: $y) isa marriage;
       """
     Then answer size is: 4
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $m (role: $x, role: $y) isa relation;
       """
@@ -1468,7 +1468,7 @@ Feature: TypeQL Match Query
       """
     Given transaction commits
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
     """
     match $r (owner: $x) isa ownership, has is-insured true; $x isa person;
     """
@@ -1495,7 +1495,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $a <value>;
       """
@@ -1520,7 +1520,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $a <value>;
       """
@@ -1549,7 +1549,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x contains "Fun";
       """
@@ -1573,7 +1573,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x contains "Bean";
       """
@@ -1597,7 +1597,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x like "^[0-9]+$";
       """
@@ -1610,12 +1610,12 @@ Feature: TypeQL Match Query
   # TODO we can't test like this because the IID is not a valid encoded IID -- need to rethink this test
   @ignore
   Scenario: when querying for a non-existent attribute type iid, an empty result is returned
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name $y; $x iid 0x83cb2;
       """
     Then answer size is: 0
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name $y; $y iid 0x83cb2;
       """
@@ -1637,7 +1637,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $x isa person, has $n;
@@ -1663,7 +1663,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has name $y; get $x;
       """
@@ -1695,7 +1695,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has attribute 9;
       """
@@ -1731,7 +1731,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age 21;
       """
@@ -1762,7 +1762,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has lucky-number 20;
       """
@@ -1790,7 +1790,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has $x;
       """
@@ -1800,7 +1800,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: an error is thrown when matching by attribute ownership, when the owned thing is actually an entity
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x has person "Luke";
       """
@@ -1808,7 +1808,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: exception is thrown when matching by an attribute ownership, if the owner can't actually own it
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa company, has age $n;
       """
@@ -1816,7 +1816,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: an error is thrown when matching by attribute ownership, when the owned type label doesn't exist
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x has bananananananana "rama";
       """
@@ -1851,7 +1851,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
         $x isa person, has graduation-date $date;
@@ -1877,7 +1877,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age == 16;
       """
@@ -1900,7 +1900,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age > 18;
       """
@@ -1923,7 +1923,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age < 18;
       """
@@ -1946,7 +1946,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has age != 18;
       """
@@ -1977,42 +1977,42 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa house-number;
         $x == 1.0;
       """
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa length;
         $x == 2;
       """
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa house-number;
         $x 1.0;
       """
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa length;
         $x 2;
       """
     Then answer size is: 1
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa attribute;
         $x >= 1;
       """
     Then answer size is: 2
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa attribute;
@@ -2020,7 +2020,7 @@ Feature: TypeQL Match Query
       """
     Then answer size is: 1
 
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa house-number;
@@ -2050,7 +2050,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x has lucky-number > 25;
       """
@@ -2073,7 +2073,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x has age == $z;
@@ -2109,7 +2109,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa attribute;
@@ -2132,7 +2132,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x isa person;
@@ -2143,7 +2143,7 @@ Feature: TypeQL Match Query
 
 
   Scenario: concept comparison of unbound variables throws an error
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match not { $x is $y; };
       """
@@ -2166,7 +2166,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa $t; { $t type person; } or {$t type company;}; get $x;
       """
@@ -2174,7 +2174,7 @@ Feature: TypeQL Match Query
       | x         |
       | key:ref:0 |
       | key:ref:1 |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa entity; {$x has name "Jeff";} or {$x has name "Amazon";};
       """
@@ -2188,12 +2188,12 @@ Feature: TypeQL Match Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa $t; { $t type person; } or {$t type company;};
       """
     Then answer size is: 0
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa $t; { $t type person; } or {$t type company;}; limit 1;
       """
@@ -2213,7 +2213,7 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has name $a; not { $a == "Jeff"; }; get $x;
       """
@@ -2226,7 +2226,7 @@ Feature: TypeQL Match Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub! thing; not { $x type thing; }; not { $x type entity; }; not { $x type relation; };
       """
@@ -2238,7 +2238,7 @@ Feature: TypeQL Match Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: read
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x isa person, has name $a; "bob" isa name;
       """
@@ -2262,22 +2262,22 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa entity;
       """
     Given answer size is: 2
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $r isa relation;
       """
     Given answer size is: 1
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x isa attribute;
       """
     Given answer size is: 5
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa $type;
       """
@@ -2301,18 +2301,18 @@ Feature: TypeQL Match Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $r isa relation;
       """
     Given answer size is: 1
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match ($x, $y) isa relation;
       """
     # 2 permutations of the roleplayers
     Given answer size is: 2
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match ($x, $y) isa $type;
       """
@@ -2327,14 +2327,14 @@ Feature: TypeQL Match Query
   # Negation resolution is handled by Reasoner, but query validation is handled by the language.
   Scenario: when the entire match clause is a negation, an error is thrown
   At least one negated pattern variable must be bound outside the negation block, so this query is invalid.
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match not { $x has attribute "value"; };
       """
     Then session transaction is open: false
 
   Scenario: when matching a negation whose pattern variables are all unbound outside it, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match
         $r isa entity;
@@ -2346,7 +2346,7 @@ Feature: TypeQL Match Query
     Then session transaction is open: false
 
   Scenario: the first variable in a negation can be unbound, as long as it is connected to a bound variable
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
         $r isa attribute;
@@ -2357,7 +2357,7 @@ Feature: TypeQL Match Query
 
   # TODO: We should verify the answers
   Scenario: negations can contain disjunctions
-    Then get answers of typeql match
+    Then get answers of typeql get
       """
       match
         $x isa entity;
@@ -2367,7 +2367,7 @@ Feature: TypeQL Match Query
       """
 
   Scenario: when negating a negation redundantly, an error is thrown
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match
         $x isa person, has name "Tim";

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -496,9 +496,9 @@ Feature: TypeQL Match Clause
     Given transaction commits
 
     Given session opens transaction of type: read
-    When typeql match; throws exception
+    When typeql get; throws exception
       """
-      match $x plays close-friendship:friend;
+      match $x plays close-friendship:friend; get;
       """
 
 

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -74,7 +74,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type person;
+      match $x type person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -93,7 +93,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub person;
+      match $x sub person; get;
       """
     Then uniquely identify answer concepts
       | x                  |
@@ -114,7 +114,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match writer sub $x;
+      match writer sub $x; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -164,6 +164,7 @@ Feature: TypeQL Match Clause
       match
         $x isa $type;
         $type sub worker;
+      get;
       """
     # Alfred and Barbara are not retrieved, as they aren't subtypes of worker
     Then uniquely identify answer concepts
@@ -197,7 +198,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub! person;
+      match $x sub! person; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -217,7 +218,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match writer sub! $x;
+      match writer sub! $x; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -249,14 +250,14 @@ Feature: TypeQL Match Clause
       """
     Then each answer satisfies
       """
-      match $x sub $z; $x iid <answer.x.iid>; $z iid <answer.z.iid>;
+      match $x sub $z; $x iid <answer.x.iid>; $z iid <answer.z.iid>; get;
       """
 
 
   Scenario: 'owns' matches types that own the specified attribute type
     When get answers of typeql get
       """
-      match $x owns age;
+      match $x owns age; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -274,7 +275,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns $x;
+      match $x owns $x; get;
       """
     Then uniquely identify answer concepts
       | x          |
@@ -295,7 +296,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns general-name;
+      match $x owns general-name; get;
       """
     Then uniquely identify answer concepts
       | x                 |
@@ -316,7 +317,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns club-name;
+      match $x owns club-name; get;
       """
     Then uniquely identify answer concepts
       | x          |
@@ -326,7 +327,7 @@ Feature: TypeQL Match Clause
   Scenario: 'owns' can be used to match attribute types that a given type owns
     When get answers of typeql get
       """
-      match person owns $x;
+      match person owns $x; get;
       """
     Then uniquely identify answer concepts
       | x           |
@@ -339,7 +340,7 @@ Feature: TypeQL Match Clause
   Scenario: directly declared 'owns' annotations are queryable
     When get answers of typeql get
       """
-      match $x owns ref @key;
+      match $x owns ref @key; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -349,7 +350,7 @@ Feature: TypeQL Match Clause
       | label:employment |
     When get answers of typeql get
       """
-      match $x owns $a @key;
+      match $x owns $a @key; get;
       """
     Then uniquely identify answer concepts
       | x                | a            |
@@ -359,14 +360,14 @@ Feature: TypeQL Match Clause
       | label:employment | label:ref    |
     When get answers of typeql get
       """
-      match $x owns email @unique;
+      match $x owns email @unique; get;
       """
     Then uniquely identify answer concepts
       | x            |
       | label:person |
     When get answers of typeql get
       """
-      match $x owns $a @unique;
+      match $x owns $a @unique; get;
       """
     Then uniquely identify answer concepts
       | x            | a            |
@@ -382,7 +383,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x owns ref @key;
+      match $x owns ref @key; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -393,7 +394,7 @@ Feature: TypeQL Match Clause
       | label:employment |
     When get answers of typeql get
       """
-      match $x owns $a @key;
+      match $x owns $a @key; get;
       """
     Then uniquely identify answer concepts
       | x                | a            |
@@ -404,7 +405,7 @@ Feature: TypeQL Match Clause
       | label:employment | label:ref    |
     When get answers of typeql get
       """
-      match $x owns email @unique;
+      match $x owns email @unique; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -412,7 +413,7 @@ Feature: TypeQL Match Clause
       | label:child  |
     When get answers of typeql get
       """
-      match $x owns $a @unique;
+      match $x owns $a @unique; get;
       """
     Then uniquely identify answer concepts
       | x            | a            |
@@ -447,6 +448,7 @@ Feature: TypeQL Match Clause
       match
         $x isa $type;
         $type owns name;
+      get;
       """
     # friendship and ref should not be retrieved, as they can't have a name
     Then uniquely identify answer concepts
@@ -459,7 +461,7 @@ Feature: TypeQL Match Clause
   Scenario: 'plays' matches types that can play the specified role
     When get answers of typeql get
       """
-      match $x plays friendship:friend;
+      match $x plays friendship:friend; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -478,7 +480,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays friendship:friend;
+      match $x plays friendship:friend; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -512,7 +514,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays close-friendship:close-friend;
+      match $x plays close-friendship:close-friend; get;
       """
     Then uniquely identify answer concepts
       | x                     |
@@ -522,7 +524,7 @@ Feature: TypeQL Match Clause
   Scenario: 'plays' can be used to match roles that a particular type can play
     When get answers of typeql get
       """
-      match person plays $x;
+      match person plays $x; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -558,6 +560,7 @@ Feature: TypeQL Match Clause
       match
         $x isa $type;
         $type plays friendship:friend;
+      get;
       """
     Then uniquely identify answer concepts
       | x         | type         |
@@ -578,7 +581,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns breed @key;
+      match $x owns breed @key; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -588,7 +591,7 @@ Feature: TypeQL Match Clause
   Scenario: 'key' can be used to find all attribute types that a given type owns as a key
     When get answers of typeql get
       """
-      match person owns $x @key;
+      match person owns $x @key; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -608,7 +611,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns breed;
+      match $x owns breed; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -619,7 +622,7 @@ Feature: TypeQL Match Clause
   Scenario: 'relates' matches relation types where the specified role can be played
     When get answers of typeql get
       """
-      match $x relates employee;
+      match $x relates employee; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -639,7 +642,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates close-friend as friend;
+      match $x relates close-friend as friend; get;
       """
     Then uniquely identify answer concepts
       | x                      |
@@ -658,7 +661,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x relates friend;
+      match $x relates friend; get;
       """
     Then uniquely identify answer concepts
       | x                |
@@ -668,7 +671,7 @@ Feature: TypeQL Match Clause
   Scenario: 'relates' can be used to retrieve all the roles of a relation type
     When get answers of typeql get
       """
-      match employment relates $x;
+      match employment relates $x; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -707,7 +710,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa $y;
+      match $x isa $y; get;
       """
     Then uniquely identify answer concepts
       | x           | y               |
@@ -750,7 +753,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa writer;
+      match $x isa writer; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -785,7 +788,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa! writer;
+      match $x isa! writer; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -808,7 +811,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then answer size is: 0
 
@@ -827,11 +830,11 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then each answer satisfies
       """
-      match $x iid <answer.x.iid>;
+      match $x iid <answer.x.iid>; get;
       """
 
 
@@ -859,18 +862,18 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa! shop;
+      match $x isa! shop; get;
       """
     Then templated typeql get; throws exception
       """
-      match $x iid <answer.x.iid>; $x isa grocery, has address "123 street";
+      match $x iid <answer.x.iid>; $x isa grocery, has address "123 street"; get;
       """
 
 
   Scenario: match returns an empty answer if there are no matches
     When get answers of typeql get
       """
-      match $x isa person, has name "Anonymous Coward";
+      match $x isa person, has name "Anonymous Coward"; get;
       """
     Then answer size is: 0
 
@@ -878,7 +881,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching by a type whose label doesn't exist, an error is thrown
     Then typeql get; throws exception
       """
-      match $x isa ganesh;
+      match $x isa ganesh; get;
       """
     Then session transaction is open: false
 
@@ -886,7 +889,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching by a relation type whose label doesn't exist, an error is thrown
     Then typeql get; throws exception
       """
-      match ($x, $y) isa $type; $type type jakas-relacja;
+      match ($x, $y) isa $type; $type type jakas-relacja; get;
       """
     Then session transaction is open: false
 
@@ -894,7 +897,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching a non-existent type label to a variable from a generic 'isa' query, an error is thrown
     Then typeql get; throws exception
       """
-      match $x isa $type; $type type polok;
+      match $x isa $type; $type type polok; get;
       """
     Then session transaction is open: false
 
@@ -915,6 +918,7 @@ Feature: TypeQL Match Clause
       match
         $x isa person;
         $y isa person;
+      get;
       """
     Then uniquely identify answer concepts
       | x         | y         |
@@ -924,7 +928,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching that a variable has a specific type, when that type is in fact a role type
     Then typeql get; throws exception
       """
-      match $x isa friendship:friend;
+      match $x isa friendship:friend; get;
       """
 
 
@@ -946,7 +950,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Then typeql get; throws exception
       """
-      match $x isa metre-rule;
+      match $x isa metre-rule; get;
       """
     Then session transaction is open: false
 
@@ -973,14 +977,14 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Then get answers of typeql get
       """
-      match $x isa person; $r (employee: $x) isa relation;
+      match $x isa person; $r (employee: $x) isa relation; get;
       """
     Then uniquely identify answer concepts
       | x         | r         |
       | key:ref:0 | key:ref:2 |
     When get answers of typeql get
       """
-      match $y isa company; $r (employer: $y) isa relation;
+      match $y isa company; $r (employer: $y) isa relation; get;
       """
     Then uniquely identify answer concepts
       | y         | r         |
@@ -1004,7 +1008,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person; $r ($x) isa relation;
+      match $x isa person; $r ($x) isa relation; get;
       """
     Then uniquely identify answer concepts
       | x         | r         |
@@ -1027,7 +1031,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Then get answers of typeql get
       """
-      match $r ($x, $y) isa employment;
+      match $r ($x, $y) isa employment; get;
       """
     Then uniquely identify answer concepts
       | x         | y         | r         |
@@ -1060,7 +1064,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (player: $x, player: $x) isa relation;
+      match $r (player: $x, player: $x) isa relation; get;
       """
     Then uniquely identify answer concepts
       | x         | r         |
@@ -1088,7 +1092,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r (player: $x) isa relation;
+      match $r (player: $x) isa relation; get;
       """
     Then uniquely identify answer concepts
       | x         | r         |
@@ -1110,7 +1114,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match (employer: $e, $role: $x) isa employment;
+      match (employer: $e, $role: $x) isa employment; get;
       """
     Then uniquely identify answer concepts
       | e         | x         | role                      |
@@ -1141,7 +1145,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r(compared:$r) isa comparator;
+      match $r(compared:$r) isa comparator; get;
       """
     Then answer size is: 1
 
@@ -1172,7 +1176,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $r(compared: $v, compared:$r) isa comparator;
+      match $r(compared: $v, compared:$r) isa comparator; get;
       """
     Then answer size is: 1
 
@@ -1193,7 +1197,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match (friend: $x, friend: $x) isa friendship;
+      match (friend: $x, friend: $x) isa friendship; get;
       """
     Then answer size is: 0
 
@@ -1236,6 +1240,7 @@ Feature: TypeQL Match Clause
       match
         (sender: $a, recipient: $b) isa gift-delivery;
         (sender: $b, recipient: $c) isa gift-delivery;
+      get;
       """
     Then uniquely identify answer concepts
       | a         | b         | c         |
@@ -1246,6 +1251,7 @@ Feature: TypeQL Match Clause
         (sender: $a, recipient: $b) isa gift-delivery;
         (sender: $b, recipient: $c) isa gift-delivery;
         (sender: $c, recipient: $d) isa gift-delivery;
+      get;
       """
     Then answer size is: 0
 
@@ -1277,7 +1283,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Given get answers of typeql get
       """
-      match $r isa relation;
+      match $r isa relation; get;
       """
     Given uniquely identify answer concepts
       | r         |
@@ -1286,14 +1292,14 @@ Feature: TypeQL Match Clause
       | key:ref:3 |
     When get answers of typeql get
       """
-      match ($x) isa relation;
+      match ($x) isa relation; get;
       """
     Then uniquely identify answer concepts
       | x         |
       | key:ref:0 |
     When get answers of typeql get
       """
-      match ($x);
+      match ($x); get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1303,7 +1309,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching an entity type as if it were a role type
     Then typeql get; throws exception
       """
-      match (person: $x) isa relation;
+      match (person: $x) isa relation; get;
       """
     Then session transaction is open: false
 
@@ -1311,7 +1317,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching an entity type as if it were a relation type
     Then typeql get; throws exception
       """
-      match ($x) isa person;
+      match ($x) isa person; get;
       """
     Then session transaction is open: false
 
@@ -1319,7 +1325,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching a non-existent type label as if it were a relation type
     Then typeql get; throws exception
       """
-      match ($x) isa bottle-of-rum;
+      match ($x) isa bottle-of-rum; get;
       """
     Then session transaction is open: false
 
@@ -1327,7 +1333,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching a role type that doesn't exist, an error is thrown
     Then typeql get; throws exception
       """
-      match (rolein-rolein-rolein: $rolein) isa relation;
+      match (rolein-rolein-rolein: $rolein) isa relation; get;
       """
     Then session transaction is open: false
 
@@ -1335,7 +1341,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching a role in a relation type that doesn't have that role, an error is thrown
     Then typeql get; throws exception
       """
-      match (friend: $x) isa employment;
+      match (friend: $x) isa employment; get;
       """
     Then session transaction is open: false
 
@@ -1377,63 +1383,63 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $m (wife: $x, husband: $y) isa hetero-marriage;
+      match $m (wife: $x, husband: $y) isa hetero-marriage; get;
       """
     Then answer size is: 1
     Then typeql get; throws exception
       """
-      match $m (wife: $x, husband: $y) isa civil-marriage;
+      match $m (wife: $x, husband: $y) isa civil-marriage; get;
       """
     Then session transaction is open: false
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $m (wife: $x, husband: $y) isa marriage;
+      match $m (wife: $x, husband: $y) isa marriage; get;
       """
     Then answer size is: 1
     When get answers of typeql get
       """
-      match $m (wife: $x, husband: $y) isa relation;
+      match $m (wife: $x, husband: $y) isa relation; get;
       """
     Then answer size is: 1
     When get answers of typeql get
       """
-      match $m (spouse: $x, spouse: $y) isa hetero-marriage;
+      match $m (spouse: $x, spouse: $y) isa hetero-marriage; get;
       """
     Then answer size is: 2
     When get answers of typeql get
       """
-      match $m (spouse: $x, spouse: $y) isa civil-marriage;
+      match $m (spouse: $x, spouse: $y) isa civil-marriage; get;
       """
     Then answer size is: 2
     When get answers of typeql get
       """
-      match $m (spouse: $x, spouse: $y) isa marriage;
+      match $m (spouse: $x, spouse: $y) isa marriage; get;
       """
     Then answer size is: 4
     When get answers of typeql get
       """
-      match $m (spouse: $x, spouse: $y) isa relation;
+      match $m (spouse: $x, spouse: $y) isa relation; get;
       """
     Then answer size is: 4
     When get answers of typeql get
       """
-      match $m (role: $x, role: $y) isa hetero-marriage;
+      match $m (role: $x, role: $y) isa hetero-marriage; get;
       """
     Then answer size is: 2
     When get answers of typeql get
       """
-      match $m (role: $x, role: $y) isa civil-marriage;
+      match $m (role: $x, role: $y) isa civil-marriage; get;
       """
     Then answer size is: 2
     When get answers of typeql get
       """
-      match $m (role: $x, role: $y) isa marriage;
+      match $m (role: $x, role: $y) isa marriage; get;
       """
     Then answer size is: 4
     When get answers of typeql get
       """
-      match $m (role: $x, role: $y) isa relation;
+      match $m (role: $x, role: $y) isa relation; get;
       """
     Then answer size is: 4
 
@@ -1470,7 +1476,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
     """
-    match $r (owner: $x) isa ownership, has is-insured true; $x isa person;
+    match $r (owner: $x) isa ownership, has is-insured true; $x isa person; get;
     """
     Then answer size is: 1
 
@@ -1497,7 +1503,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $a <value>;
+      match $a <value>; get;
       """
     Then uniquely identify answer concepts
       | a         |
@@ -1522,7 +1528,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $a <value>;
+      match $a <value>; get;
       """
     Then answer size is: 0
 
@@ -1551,7 +1557,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x contains "Fun";
+      match $x contains "Fun"; get;
       """
     Then uniquely identify answer concepts
       | x                                      |
@@ -1575,7 +1581,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x contains "Bean";
+      match $x contains "Bean"; get;
       """
     Then uniquely identify answer concepts
       | x                                   |
@@ -1599,7 +1605,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x like "^[0-9]+$";
+      match $x like "^[0-9]+$"; get;
       """
     Then uniquely identify answer concepts
       | x                 |
@@ -1612,12 +1618,12 @@ Feature: TypeQL Match Clause
   Scenario: when querying for a non-existent attribute type iid, an empty result is returned
     When get answers of typeql get
       """
-      match $x has name $y; $x iid 0x83cb2;
+      match $x has name $y; $x iid 0x83cb2; get;
       """
     Then answer size is: 0
     When get answers of typeql get
       """
-      match $x has name $y; $y iid 0x83cb2;
+      match $x has name $y; $y iid 0x83cb2; get;
       """
     Then answer size is: 0
 
@@ -1642,6 +1648,7 @@ Feature: TypeQL Match Clause
       match
       $x isa person, has $n;
       $y isa person, has $n;
+      get;
       """
 
   #######################
@@ -1697,7 +1704,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has attribute 9;
+      match $x has attribute 9; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1733,7 +1740,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has age 21;
+      match $x has age 21; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1764,7 +1771,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has lucky-number 20;
+      match $x has lucky-number 20; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1792,7 +1799,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has $x;
+      match $x has $x; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1802,7 +1809,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching by attribute ownership, when the owned thing is actually an entity
     Then typeql get; throws exception
       """
-      match $x has person "Luke";
+      match $x has person "Luke"; get;
       """
     Then session transaction is open: false
 
@@ -1810,7 +1817,7 @@ Feature: TypeQL Match Clause
   Scenario: exception is thrown when matching by an attribute ownership, if the owner can't actually own it
     Then typeql get; throws exception
       """
-      match $x isa company, has age $n;
+      match $x isa company, has age $n; get;
       """
     Then session transaction is open: false
 
@@ -1818,7 +1825,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching by attribute ownership, when the owned type label doesn't exist
     Then typeql get; throws exception
       """
-      match $x has bananananananana "rama";
+      match $x has bananananananana "rama"; get;
       """
     Then session transaction is open: false
 
@@ -1856,6 +1863,7 @@ Feature: TypeQL Match Clause
       match
         $x isa person, has graduation-date $date;
         $r (employee: $x) isa employment, has start-date == $date;
+      get;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts
@@ -1879,7 +1887,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has age == 16;
+      match $x has age == 16; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1902,7 +1910,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has age > 18;
+      match $x has age > 18; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1925,7 +1933,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has age < 18;
+      match $x has age < 18; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1948,7 +1956,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has age != 18;
+      match $x has age != 18; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -1982,6 +1990,7 @@ Feature: TypeQL Match Clause
       match
         $x isa house-number;
         $x == 1.0;
+      get;
       """
     Then answer size is: 1
     When get answers of typeql get
@@ -1989,6 +1998,7 @@ Feature: TypeQL Match Clause
       match
         $x isa length;
         $x == 2;
+      get;
       """
     Then answer size is: 1
     When get answers of typeql get
@@ -1996,6 +2006,7 @@ Feature: TypeQL Match Clause
       match
         $x isa house-number;
         $x 1.0;
+      get;
       """
     Then answer size is: 1
     When get answers of typeql get
@@ -2003,6 +2014,7 @@ Feature: TypeQL Match Clause
       match
         $x isa length;
         $x 2;
+      get;
       """
     Then answer size is: 1
     When get answers of typeql get
@@ -2010,6 +2022,7 @@ Feature: TypeQL Match Clause
       match
         $x isa attribute;
         $x >= 1;
+      get;
       """
     Then answer size is: 2
     When get answers of typeql get
@@ -2017,6 +2030,7 @@ Feature: TypeQL Match Clause
       match
         $x isa attribute;
         $x < 2.0;
+      get;
       """
     Then answer size is: 1
 
@@ -2026,6 +2040,7 @@ Feature: TypeQL Match Clause
         $x isa house-number;
         $y isa length;
         $x < $y;
+      get;
       """
     Then answer size is: 1
 
@@ -2052,7 +2067,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x has lucky-number > 25;
+      match $x has lucky-number > 25; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -2114,6 +2129,7 @@ Feature: TypeQL Match Clause
       match
         $x isa attribute;
         $x > 20;
+      get;
       """
     Then uniquely identify answer concepts
       | x                 |
@@ -2138,6 +2154,7 @@ Feature: TypeQL Match Clause
         $x isa person;
         $y isa person;
         not { $x is $y; };
+      get;
       """
     Then answer size is: 0
 
@@ -2145,7 +2162,7 @@ Feature: TypeQL Match Clause
   Scenario: concept comparison of unbound variables throws an error
     Then typeql get; throws exception
       """
-      match not { $x is $y; };
+      match not { $x is $y; }; get;
       """
     Then session transaction is open: false
 
@@ -2176,7 +2193,7 @@ Feature: TypeQL Match Clause
       | key:ref:1 |
     When get answers of typeql get
       """
-      match $x isa entity; {$x has name "Jeff";} or {$x has name "Amazon";};
+      match $x isa entity; {$x has name "Jeff";} or {$x has name "Amazon";}; get;
       """
     Then uniquely identify answer concepts
       | x         |
@@ -2190,12 +2207,12 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa $t; { $t type person; } or {$t type company;};
+      match $x isa $t; { $t type person; } or {$t type company;}; get;
       """
     Then answer size is: 0
     When get answers of typeql get
       """
-      match $x isa $t; { $t type person; } or {$t type company;}; limit 1;
+      match $x isa $t; { $t type person; } or {$t type company;}; get; limit 1;
       """
     Then answer size is: 0
 
@@ -2228,7 +2245,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub! thing; not { $x type thing; }; not { $x type entity; }; not { $x type relation; };
+      match $x sub! thing; not { $x type thing; }; not { $x type entity; }; not { $x type relation; }; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -2240,7 +2257,7 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Then typeql get; throws exception
       """
-      match $x isa person, has name $a; "bob" isa name;
+      match $x isa person, has name $a; "bob" isa name; get;
       """
 
 
@@ -2264,22 +2281,22 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Given get answers of typeql get
       """
-      match $x isa entity;
+      match $x isa entity; get;
       """
     Given answer size is: 2
     Given get answers of typeql get
       """
-      match $r isa relation;
+      match $r isa relation; get;
       """
     Given answer size is: 1
     Given get answers of typeql get
       """
-      match $x isa attribute;
+      match $x isa attribute; get;
       """
     Given answer size is: 5
     When get answers of typeql get
       """
-      match $x isa $type;
+      match $x isa $type; get;
       """
     # 2 entities x 3 types {person,entity,thing}
     # 1 relation x 3 types {friendship,relation,thing}
@@ -2303,18 +2320,18 @@ Feature: TypeQL Match Clause
     Given session opens transaction of type: read
     Given get answers of typeql get
       """
-      match $r isa relation;
+      match $r isa relation; get;
       """
     Given answer size is: 1
     Given get answers of typeql get
       """
-      match ($x, $y) isa relation;
+      match ($x, $y) isa relation; get;
       """
     # 2 permutations of the roleplayers
     Given answer size is: 2
     When get answers of typeql get
       """
-      match ($x, $y) isa $type;
+      match ($x, $y) isa $type; get;
       """
     # 2 permutations x 3 types {friendship,relation,thing}
     Then answer size is: 6
@@ -2329,7 +2346,7 @@ Feature: TypeQL Match Clause
   At least one negated pattern variable must be bound outside the negation block, so this query is invalid.
     Then typeql get; throws exception
       """
-      match not { $x has attribute "value"; };
+      match not { $x has attribute "value"; }; get;
       """
     Then session transaction is open: false
 
@@ -2342,6 +2359,7 @@ Feature: TypeQL Match Clause
           ($r2, $i);
           $i isa entity;
         };
+      get;
       """
     Then session transaction is open: false
 
@@ -2353,6 +2371,7 @@ Feature: TypeQL Match Clause
         not {
           $x isa entity, has attribute $r;
         };
+      get;
       """
 
   # TODO: We should verify the answers
@@ -2364,6 +2383,7 @@ Feature: TypeQL Match Clause
         not {
           { $x has attribute 1; } or { $x has attribute 2; };
         };
+      get;
       """
 
   Scenario: when negating a negation redundantly, an error is thrown
@@ -2376,4 +2396,5 @@ Feature: TypeQL Match Clause
             $x has age 55;
           };
         };
+      get;
       """

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -92,6 +92,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>;
+      get;
       sort $x asc;
       """
     Then order of answer concepts is
@@ -124,6 +125,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y asc;
       """
     Then order of answer concepts is
@@ -135,6 +137,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y desc;
       """
     Then order of answer concepts is
@@ -160,6 +163,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y;
       """
     Then order of answer concepts is
@@ -187,6 +191,7 @@ Feature: TypeQL Query Modifiers
       match
         $x isa person, has age $a;
         ?to20 = 20 - $a;
+      get;
       sort
         ?to20 desc;
       """
@@ -213,6 +218,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y, has ref $r, has age $a;
+      get;
       sort $y, $a, $r asc;
       """
     Then order of answer concepts is
@@ -238,6 +244,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y, has ref $r, has age $a;
+      get;
       sort $y asc, $a desc, $r desc;
       """
     Then order of answer concepts is
@@ -263,6 +270,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y asc;
       limit 3;
       """
@@ -288,6 +296,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y asc;
       offset 2;
       """
@@ -312,6 +321,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y asc;
       offset 1;
       limit 2;
@@ -337,6 +347,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y asc;
       limit 0;
       """
@@ -358,6 +369,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has name $y;
+      get;
       sort $y asc;
       offset 5;
       """
@@ -380,6 +392,7 @@ Feature: TypeQL Query Modifiers
     Then get answers of typeql get
       """
       match $x isa name;
+      get;
       sort $x asc;
       """
     Then order of answer concepts is
@@ -407,6 +420,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has age $y;
+      get;
       sort $y asc;
       limit 2;
       """
@@ -417,6 +431,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa person, has age $y;
+      get;
       sort $y asc;
       offset 2;
       limit 2;
@@ -460,6 +475,7 @@ Feature: TypeQL Query Modifiers
       """
       match
         $x isa person, attribute $a;
+      get;
       sort $a asc;
       """
 
@@ -493,6 +509,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x < <pivot>;
+      get;
       sort $x asc;
       """
     Then order of answer concepts is
@@ -502,6 +519,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x <= <pivot>;
+      get;
       sort $x asc;
       """
     Then order of answer concepts is
@@ -512,6 +530,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x > <pivot>;
+      get;
       sort $x asc;
       """
     Then order of answer concepts is
@@ -521,6 +540,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x >= <pivot>;
+      get;
       sort $x asc;
       """
     Then order of answer concepts is
@@ -532,6 +552,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x < <pivot>;
+      get;
       sort $x desc;
       """
     Then order of answer concepts is
@@ -541,6 +562,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x <= <pivot>;
+      get;
       sort $x desc;
       """
     Then order of answer concepts is
@@ -551,6 +573,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x > <pivot>;
+      get;
       sort $x desc;
       """
     Then order of answer concepts is
@@ -560,6 +583,7 @@ Feature: TypeQL Query Modifiers
     When get answers of typeql get
       """
       match $x isa <attr>; $x >= <pivot>;
+      get;
       sort $x desc;
       """
     Then order of answer concepts is
@@ -886,6 +910,7 @@ Feature: TypeQL Query Modifiers
       """
       match
       $x isa person, has name $n;
+      get;
       sort $n;
       """
     Then uniquely identify answer concepts
@@ -924,6 +949,7 @@ Feature: TypeQL Query Modifiers
       """
       match
       $x isa person, has email "dummy@gmail.com";
+      get;
       """
     Then uniquely identify answer concepts
       | x         |

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -839,15 +839,18 @@ Feature: TypeQL Query Modifiers
         {
           "person": {
             "type": { "label": "person", "root": "entity" },
-            "name": [ { "type": { "label": "name", "root": "attribute" }, "value": "Frederick"}, { "type": { "label": "name", "root": "attribute" }, "value": "Freddy" } ],
-            "email": [ { "type": { "label": "email", "root": "attribute" }, "value": "frederick@gmail.com" } ]
+            "name": [
+              { "type": { "label": "name", "root": "attribute" }, "value": "Frederick", "value_type": "string" },
+              { "type": { "label": "name", "root": "attribute" }, "value": "Freddy", "value_type": "string" }
+            ],
+            "email": [ { "type": { "label": "email", "root": "attribute" }, "value": "frederick@gmail.com", "value_type": "string" } ]
           },
           "ref": { "type" : { "label": "ref", "root": "attribute" }, "value": 2, "value_type": "long" }
         },
         {
           "person": {
             "type":  { "label": "person", "root": "entity" },
-            "name": [ { "type": { "label": "name", "root": "attribute" }, "value": "Jemima" } ],
+            "name": [ { "type": { "label": "name", "root": "attribute" }, "value": "Jemima", "value_type": "string" } ],
             "email": [ ]
           },
           "ref": { "type" : { "label": "ref", "root": "attribute" }, "value" : 1, "value_type": "long" }

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -1,0 +1,714 @@
+#
+# Copyright (C) 2022 Vaticle
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+Feature: TypeQL Query Modifiers
+
+  # ------------- read queries -------------
+
+  ########
+  # SORT #
+  ########
+
+  Scenario Outline: the answers of a match can be sorted by an attribute of type '<type>'
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      <attr> sub attribute, value <type>, owns ref @key;
+      """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert
+      $a <val1> isa <attr>, has ref 0;
+      $b <val2> isa <attr>, has ref 1;
+      $c <val3> isa <attr>, has ref 2;
+      $d <val4> isa <attr>, has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa <attr>;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:3 |
+      | key:ref:1 |
+      | key:ref:2 |
+      | key:ref:0 |
+
+    Examples:
+      | attr          | type     | val4       | val2             | val3             | val1       |
+      | colour        | string   | "blue"     | "green"          | "red"            | "yellow"   |
+      | score         | long     | -38        | -4               | 18               | 152        |
+      | correlation   | double   | -29.7      | -0.9             | 0.01             | 100.0      |
+      | date-of-birth | datetime | 1970-01-01 | 1999-12-31T23:00 | 1999-12-31T23:01 | 2020-02-29 |
+
+
+  Scenario: sort order can be ascending or descending
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y asc;
+      """
+    Then order of answer concepts is
+      | x         | y                    |
+      | key:ref:3 | attr:name:Brenda     |
+      | key:ref:2 | attr:name:Frederick  |
+      | key:ref:0 | attr:name:Gary       |
+      | key:ref:1 | attr:name:Jemima     |
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y desc;
+      """
+    Then order of answer concepts is
+      | x         | y                    |
+      | key:ref:1 | attr:name:Jemima     |
+      | key:ref:0 | attr:name:Gary       |
+      | key:ref:2 | attr:name:Frederick  |
+      | key:ref:3 | attr:name:Brenda     |
+
+
+  Scenario: the default sort order is ascending
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y;
+      """
+    Then order of answer concepts is
+      | x         | y                    |
+      | key:ref:3 | attr:name:Brenda     |
+      | key:ref:2 | attr:name:Frederick  |
+      | key:ref:0 | attr:name:Gary       |
+      | key:ref:1 | attr:name:Jemima     |
+
+
+  Scenario: Sorting on value variables is supported
+    Given typeql insert
+      """
+      insert
+      $a isa person, has age 18, has ref 0;
+      $b isa person, has age 14, has ref 1;
+      $c isa person, has age 20, has ref 2;
+      $d isa person, has age 16, has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match
+        $x isa person, has age $a;
+        ?to20 = 20 - $a;
+      sort
+        ?to20 desc;
+      """
+    Then order of answer concepts is
+      | x         | to20         |
+      | key:ref:1 | value:long:6 |
+      | key:ref:3 | value:long:4 |
+      | key:ref:0 | value:long:2 |
+      | key:ref:2 | value:long:0 |
+
+
+  Scenario: multiple sort variables may be used to sort ascending
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0, has age 15;
+      $b isa person, has name "Gary", has ref 1, has age 5;
+      $c isa person, has name "Gary", has ref 2, has age 25;
+      $d isa person, has name "Brenda", has ref 3, has age 12;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y, has ref $r, has age $a;
+      sort $y, $a, $r asc;
+      """
+    Then order of answer concepts is
+      | y                 |  a           | x         |
+      | attr:name:Brenda  | attr:age:12  | key:ref:3 |
+      | attr:name:Gary    | attr:age:5   | key:ref:1 |
+      | attr:name:Gary    | attr:age:15  | key:ref:0 |
+      | attr:name:Gary    | attr:age:25  | key:ref:2 |
+
+
+  Scenario: multiple sort variables may be used to sort ascending or descending
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0, has age 15;
+      $b isa person, has name "Gary", has ref 1, has age 5;
+      $c isa person, has name "Gary", has ref 2, has age 25;
+      $d isa person, has name "Brenda", has ref 3, has age 12;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y, has ref $r, has age $a;
+      sort $y asc, $a desc, $r desc;
+      """
+    Then order of answer concepts is
+      | y                 |  a           | x         |
+      | attr:name:Brenda  | attr:age:12  | key:ref:3 |
+      | attr:name:Gary    | attr:age:25  | key:ref:2 |
+      | attr:name:Gary    | attr:age:15  | key:ref:0 |
+      | attr:name:Gary    | attr:age:5   | key:ref:1 |
+
+
+  Scenario: a sorted result set can be limited to a specific size
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y asc;
+      limit 3;
+      """
+    Then order of answer concepts is
+      | x         | y                    |
+      | key:ref:3 | attr:name:Brenda     |
+      | key:ref:2 | attr:name:Frederick  |
+      | key:ref:0 | attr:name:Gary       |
+
+
+  Scenario: sorted results can be retrieved starting from a specific offset
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y asc;
+      offset 2;
+      """
+    Then order of answer concepts is
+      | x         | y                 |
+      | key:ref:0 | attr:name:Gary    |
+      | key:ref:1 | attr:name:Jemima  |
+
+
+  Scenario: 'offset' and 'limit' can be used together to restrict the answer set
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y asc;
+      offset 1;
+      limit 2;
+      """
+    Then order of answer concepts is
+      | x         | y                    |
+      | key:ref:2 | attr:name:Frederick  |
+      | key:ref:0 | attr:name:Gary       |
+
+
+  Scenario: when the answer size is limited to 0, an empty answer set is returned
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y asc;
+      limit 0;
+      """
+    Then answer size is: 0
+
+
+  Scenario: when the offset is outside the bounds of the matched answer set, an empty answer set is returned
+    Given typeql insert
+      """
+      insert
+      $a isa person, has name "Gary", has ref 0;
+      $b isa person, has name "Jemima", has ref 1;
+      $c isa person, has name "Frederick", has ref 2;
+      $d isa person, has name "Brenda", has ref 3;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has name $y;
+      sort $y asc;
+      offset 5;
+      """
+    Then answer size is: 0
+
+
+  Scenario: string sorting is case-sensitive
+    Given typeql insert
+      """
+      insert
+      $a "Bond" isa name;
+      $b "James Bond" isa name;
+      $c "007" isa name;
+      $d "agent" isa name;
+      $e "secret agent" isa name;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    Then get answers of typeql get
+      """
+      match $x isa name;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x                       |
+      | attr:name:007           |
+      | attr:name:Bond          |
+      | attr:name:James Bond    |
+      | attr:name:agent         |
+      | attr:name:secret agent  |
+
+
+  Scenario: sort is able to correctly handle duplicates in the value set
+    Given typeql insert
+      """
+      insert
+      $a isa person, has age 2, has ref 0;
+      $b isa person, has age 6, has ref 1;
+      $c isa person, has age 12, has ref 2;
+      $d isa person, has age 6, has ref 3;
+      $e isa person, has age 2, has ref 4;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When get answers of typeql get
+      """
+      match $x isa person, has age $y;
+      sort $y asc;
+      limit 2;
+      """
+    Then uniquely identify answer concepts
+      | x         | y           |
+      | key:ref:0 | attr:age:2  |
+      | key:ref:4 | attr:age:2  |
+    When get answers of typeql get
+      """
+      match $x isa person, has age $y;
+      sort $y asc;
+      offset 2;
+      limit 2;
+      """
+    Then uniquely identify answer concepts
+      | x         | y           |
+      | key:ref:1 | attr:age:6  |
+      | key:ref:3 | attr:age:6  |
+
+
+  Scenario: when sorting by a variable not contained in the answer set, an error is thrown
+    Given typeql insert
+      """
+      insert
+      $a isa person, has age 2, has ref 0;
+      $b isa person, has age 6, has ref 1;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    Then typeql get; throws exception
+      """
+      match
+        $x isa person, has age $y;
+      get $x;
+      sort $y asc;
+      limit 2;
+      """
+
+  Scenario: when sorting by a variable that may contain incomparable values, an error is thrown
+    Given typeql insert
+      """
+      insert
+      $a isa person, has age 2, has name "Abby", has ref 0;
+      $b isa person, has age 6, has name "Bobby", has ref 1;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    Then typeql get; throws exception
+      """
+      match
+        $x isa person, attribute $a;
+      sort $a asc;
+      """
+
+
+  Scenario Outline: sorting and query predicates agree for type '<type>'
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      <attr> sub attribute, value <type>, owns ref @key;
+      """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert
+      $a <pivot> isa <attr>, has ref 0;
+      $b <lesser> isa <attr>, has ref 1;
+      $c <greater> isa <attr>, has ref 2;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+
+    # ascending
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x < <pivot>;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:1 |
+
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x <= <pivot>;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:1 |
+      | key:ref:0 |
+
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x > <pivot>;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:2 |
+
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x >= <pivot>;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:0 |
+      | key:ref:2 |
+
+    # descending
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x < <pivot>;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:1 |
+
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x <= <pivot>;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:0 |
+      | key:ref:1 |
+
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x > <pivot>;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:2 |
+
+    When get answers of typeql get
+      """
+      match $x isa <attr>; $x >= <pivot>;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:2 |
+      | key:ref:0 |
+
+    Examples:
+      | attr          | type     | pivot      | lesser       | greater          |
+      | colour        | string   | "green"    | "blue"       | "red"            |
+      | score         | long     | -4         | -38          | 18               |
+      | correlation   | double   | -0.9       | -1.2         | 0.01             |
+      | date-of-birth | datetime | 1970-02-01 |  1970-01-01  | 1999-12-31T23:01 |
+
+
+  Scenario Outline: sorting and query predicates produce order ignoring types
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      <firstAttr> sub attribute, value <firstType>, owns ref @key;
+      <secondAttr> sub attribute, value <secondType>, owns ref @key;
+      <thirdAttr> sub attribute, value <thirdType>, owns ref @key;
+      <fourthAttr> sub attribute, value <fourthType>, owns ref @key;
+      """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql insert
+      """
+      insert
+      $first1 <firstValue1> isa <firstAttr>, has ref 0;
+      $first2 <firstValue2> isa <firstAttr>, has ref 1;
+      $second <secondValue> isa <secondAttr>, has ref 2;
+      $third <thirdValue> isa <thirdAttr>, has ref 3;
+      $fourth <fourthValuePivot> isa <fourthAttr>, has ref 4;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+
+    # ascending
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref;
+      get $x;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:2 |
+      | key:ref:1 |
+      | key:ref:4 |
+      | key:ref:0 |
+      | key:ref:3 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x < <fourthValuePivot>;
+      get $x;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:2 |
+      | key:ref:1 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x <= <fourthValuePivot>;
+      get $x;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:2 |
+      | key:ref:1 |
+      | key:ref:4 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x > <fourthValuePivot>;
+      get $x;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:0 |
+      | key:ref:3 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x >= <fourthValuePivot>;
+      get $x;
+      sort $x asc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:4 |
+      | key:ref:0 |
+      | key:ref:3 |
+
+    # descending
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref;
+      get $x;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:3 |
+      | key:ref:0 |
+      | key:ref:4 |
+      | key:ref:1 |
+      | key:ref:2 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x < <fourthValuePivot>;
+      get $x;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:1 |
+      | key:ref:2 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x <= <fourthValuePivot>;
+      get $x;
+      sort $x desc;G
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:4 |
+      | key:ref:1 |
+      | key:ref:2 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x > <fourthValuePivot>;
+      get $x;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:3 |
+      | key:ref:0 |
+
+    When get answers of typeql get
+      """
+      match $x isa $t; $t owns ref; $x >= <fourthValuePivot>;
+      get $x;
+      sort $x desc;
+      """
+    Then order of answer concepts is
+      | x         |
+      | key:ref:3 |
+      | key:ref:0 |
+      | key:ref:4 |
+
+    Examples:
+      # NOTE: fourthValuePivot is expected to be the middle of the sort order (pivot)
+      | firstAttr   | firstType | firstValue1 | firstValue2 | secondAttr | secondType | secondValue | thirdAttr | thirdType | thirdValue | fourthAttr | fourthType | fourthValuePivot |
+      | colour      | string    | "green"     | "blue"      | name       | string     | "alice"     | shape     | string    | "square"   | street     | string     | "carnaby"        |
+      | score       | long      | 4           | -38         | quantity   | long       | -50         | area      | long      | 100        | length     | long       | 0                |
+      | correlation | double    | 4.1         | -38.999     | quantity   | double     | -101.4      | area      | double    | 110.0555   | length     | double     | 0.5              |
+      # mixed double-long data
+      | score       | long      | 4           | -38         | quantity   | double     | -55.123     | area      | long      | 100        | length     | double     | 0.5              |
+      | dob         | datetime  | 2970-01-01   | 1970-02-01 | start-date | datetime   | 1970-01-01  | end-date  | datetime  | 3100-11-20 | last-date  | datetime   | 2000-08-03       |
+
+
+
+  # TODO: extra read query tests for
+  #  1. Get + Modifiers + Group
+  #  2. Get + Modifiers + Group + Aggregate
+  #  3. Fetch + Modifiers
+
+
+  # ------------- write queries -------------
+
+  # TODO: write query tests for
+  #  1. Match-Insert with Modifiers
+  #  2. Match-Delete with Modifiers
+  #  3. Match-Delete-Insert with Modifiers
+
+

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -48,7 +48,7 @@ Feature: TypeQL Undefine Query
   Scenario: calling 'undefine' with 'sub entity' on a subtype of 'entity' deletes it
     Given get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -64,7 +64,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -89,7 +89,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x sub person;
+      match $x sub person; get;
       """
     Given uniquely identify answer concepts
       | x            |
@@ -104,7 +104,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub person;
+      match $x sub person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -121,7 +121,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub person;
+      match $x sub person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -137,7 +137,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub person;
+      match $x sub person; get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -175,7 +175,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type child; $x plays employment:employee;
+      match $x type child; $x plays employment:employee; get;
       """
     Then answer size is: 0
 
@@ -197,7 +197,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type child; $x owns name;
+      match $x type child; $x owns name; get;
       """
     Then answer size is: 0
 
@@ -219,14 +219,14 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type child; $x owns email @key;
+      match $x type child; $x owns email @key; get;
       """
     Then answer size is: 0
 
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
     Given get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -276,7 +276,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -291,7 +291,7 @@ Feature: TypeQL Undefine Query
   Scenario: undefining a relation type removes it
     Given get answers of typeql get
       """
-      match $x sub relation;
+      match $x sub relation; get;
       """
     Given uniquely identify answer concepts
       | x                |
@@ -306,7 +306,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub relation;
+      match $x sub relation; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -326,7 +326,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match contract-employment plays $x;
+      match contract-employment plays $x; get;
       """
     Given uniquely identify answer concepts
       | x                                 |
@@ -340,7 +340,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match contract-employment plays $x;
+      match contract-employment plays $x; get;
       """
     Then answer size is: 0
 
@@ -358,7 +358,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x owns start-date;
+      match $x owns start-date; get;
       """
     Given uniquely identify answer concepts
       | x                         |
@@ -373,7 +373,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns start-date;
+      match $x owns start-date; get;
       """
     Then answer size is: 0
 
@@ -391,7 +391,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x owns employment-reference @key;
+      match $x owns employment-reference @key; get;
       """
     Given uniquely identify answer concepts
       | x                         |
@@ -406,7 +406,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns employment-reference @key;
+      match $x owns employment-reference @key; get;
       """
     Then answer size is: 0
 
@@ -439,7 +439,7 @@ Feature: TypeQL Undefine Query
   Scenario: all existing instances of a relation type must be deleted in order to undefine it
     Given get answers of typeql get
       """
-      match $x sub relation;
+      match $x sub relation; get;
       """
     Given uniquely identify answer concepts
       | x                |
@@ -488,7 +488,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub relation;
+      match $x sub relation; get;
       """
     Then uniquely identify answer concepts
       | x              |
@@ -501,6 +501,7 @@ Feature: TypeQL Undefine Query
       match
         $x type person;
         $x plays $y;
+      get;
       """
     Given uniquely identify answer concepts
       | x            | y                         |
@@ -517,6 +518,7 @@ Feature: TypeQL Undefine Query
       match
         $x type person;
         $x plays $y;
+      get;
       """
     Then answer size is: 0
 
@@ -528,7 +530,7 @@ Feature: TypeQL Undefine Query
   Scenario: a role type can be removed from its relation type
     Given get answers of typeql get
       """
-      match employment relates $x;
+      match employment relates $x; get;
       """
     Given uniquely identify answer concepts
       | x                         |
@@ -543,7 +545,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match employment relates $x;
+      match employment relates $x; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -560,7 +562,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x plays employment:employee;
+      match $x plays employment:employee; get;
       """
     Then answer size is: 0
 
@@ -604,7 +606,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x relates employee;
+      match $x relates employee; get;
       """
     Then answer size is: 0
     Then typeql insert; throws exception
@@ -632,6 +634,7 @@ Feature: TypeQL Undefine Query
       match
         $x type person;
         $x plays $y;
+      get;
       """
     Given uniquely identify answer concepts
       | x            | y                         |
@@ -648,6 +651,7 @@ Feature: TypeQL Undefine Query
       match
         $x type person;
         $x plays $y;
+      get;
       """
     Then answer size is: 0
 
@@ -705,7 +709,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match employment relates $x;
+      match employment relates $x; get;
       """
     Then uniquely identify answer concepts
       | x                         |
@@ -729,7 +733,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x type part-time; $x relates $role;
+      match $x type part-time; $x relates $role; get;
       """
     Then uniquely identify answer concepts
       | x               | role                      |
@@ -782,7 +786,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: write
     When get answers of typeql get
       """
-      match $x plays employment:employee;
+      match $x plays employment:employee; get;
       """
     Then answer size is: 0
     Then typeql insert; throws exception
@@ -797,7 +801,7 @@ Feature: TypeQL Undefine Query
   Scenario: undefining a playable role that was not actually playable to begin with throws
     Given get answers of typeql get
       """
-      match person plays $x;
+      match person plays $x; get;
       """
     Given uniquely identify answer concepts
       | x                         |
@@ -859,7 +863,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x type <attr>;
+      match $x type <attr>; get;
       """
     Given answer size is: 1
     When typeql undefine
@@ -871,7 +875,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     Then typeql get; throws exception
       """
-      match $x type <attr>;
+      match $x type <attr>; get;
       """
 
     Examples:
@@ -902,7 +906,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa email;
+      match $x isa email; get;
       """
     Then answer size is: 1
 
@@ -920,7 +924,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match first-name plays $x;
+      match first-name plays $x; get;
       """
     Given uniquely identify answer concepts
       | x                             |
@@ -934,7 +938,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match first-name plays $x;
+      match first-name plays $x; get;
       """
     Then answer size is: 0
 
@@ -952,7 +956,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x owns locale;
+      match $x owns locale; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -967,7 +971,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns locale;
+      match $x owns locale; get;
       """
     Then answer size is: 0
 
@@ -985,7 +989,7 @@ Feature: TypeQL Undefine Query
     Given session opens transaction of type: write
     Given get answers of typeql get
       """
-      match $x owns name-id @key;
+      match $x owns name-id @key; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -1000,7 +1004,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns name-id @key;
+      match $x owns name-id @key; get;
       """
     Then answer size is: 0
 
@@ -1025,7 +1029,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     Then typeql get; throws exception
       """
-      match $x type name;
+      match $x type name; get;
       """
 
 
@@ -1039,7 +1043,7 @@ Feature: TypeQL Undefine Query
   Scenario: all existing instances of an attribute type must be deleted in order to undefine it
     Given get answers of typeql get
       """
-      match $x sub attribute;
+      match $x sub attribute; get;
       """
     Given uniquely identify answer concepts
       | x               |
@@ -1087,7 +1091,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub attribute;
+      match $x sub attribute; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -1105,6 +1109,7 @@ Feature: TypeQL Undefine Query
       match
         $x owns name;
         $x type person;
+      get;
       """
     Given uniquely identify answer concepts
       | x            |
@@ -1121,6 +1126,7 @@ Feature: TypeQL Undefine Query
       match
         $x owns name;
         $x type person;
+      get;
       """
     Then answer size is: 0
 
@@ -1156,7 +1162,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns email;
+      match $x owns email; get;
       """
     Then answer size is: 0
 
@@ -1178,7 +1184,7 @@ Feature: TypeQL Undefine Query
   Scenario: when a type can own an attribute, but none of its instances actually do, the ownership can be undefined
     Given get answers of typeql get
       """
-      match $x owns name;
+      match $x owns name; get;
       """
     Given uniquely identify answer concepts
       | x            |
@@ -1206,7 +1212,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x owns name;
+      match $x owns name; get;
       """
     Then answer size is: 0
 
@@ -1489,6 +1495,7 @@ Feature: TypeQL Undefine Query
       match
         $x type abstract-type;
         not { $x abstract; };
+      get;
       """
     Given answer size is: 0
     Given connection close all sessions
@@ -1516,6 +1523,7 @@ Feature: TypeQL Undefine Query
       match
         $x type abstract-type;
         not { $x abstract; };
+      get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -1529,7 +1537,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa abstract-type;
+      match $x isa abstract-type; get;
       """
     Then answer size is: 1
 
@@ -1547,6 +1555,7 @@ Feature: TypeQL Undefine Query
       match
         $x type person;
         not { $x abstract; };
+      get;
       """
     Then uniquely identify answer concepts
       | x            |
@@ -1573,6 +1582,7 @@ Feature: TypeQL Undefine Query
       match
         $x type abstract-type;
         not { $x abstract; };
+      get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -1603,6 +1613,7 @@ Feature: TypeQL Undefine Query
       match
         $x type vehicle-registration;
         not { $x abstract; };
+      get;
       """
     Then answer size is: 1
 
@@ -1614,7 +1625,7 @@ Feature: TypeQL Undefine Query
   Scenario: a type and an attribute type that it owns can be removed simultaneously
     Given get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -1623,7 +1634,7 @@ Feature: TypeQL Undefine Query
       | label:entity        |
     Given get answers of typeql get
       """
-      match $x sub attribute;
+      match $x sub attribute; get;
       """
     Given uniquely identify answer concepts
       | x               |
@@ -1641,7 +1652,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -1649,7 +1660,7 @@ Feature: TypeQL Undefine Query
       | label:entity        |
     When get answers of typeql get
       """
-      match $x sub attribute;
+      match $x sub attribute; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -1659,7 +1670,7 @@ Feature: TypeQL Undefine Query
   Scenario: a type, a relation type that it plays in and an attribute type that it owns can be removed simultaneously
     Given get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Given uniquely identify answer concepts
       | x                   |
@@ -1668,7 +1679,7 @@ Feature: TypeQL Undefine Query
       | label:entity        |
     Given get answers of typeql get
       """
-      match $x sub relation;
+      match $x sub relation; get;
       """
     Given uniquely identify answer concepts
       | x                |
@@ -1676,7 +1687,7 @@ Feature: TypeQL Undefine Query
       | label:relation   |
     Given get answers of typeql get
       """
-      match $x sub attribute;
+      match $x sub attribute; get;
       """
     Given uniquely identify answer concepts
       | x               |
@@ -1685,7 +1696,7 @@ Feature: TypeQL Undefine Query
       | label:attribute |
     Given get answers of typeql get
       """
-      match $x sub relation:role;
+      match $x sub relation:role; get;
       """
     Given uniquely identify answer concepts
       | x                         |
@@ -1704,7 +1715,7 @@ Feature: TypeQL Undefine Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x sub entity;
+      match $x sub entity; get;
       """
     Then uniquely identify answer concepts
       | x                   |
@@ -1712,14 +1723,14 @@ Feature: TypeQL Undefine Query
       | label:entity        |
     When get answers of typeql get
       """
-      match $x sub relation;
+      match $x sub relation; get;
       """
     Then uniquely identify answer concepts
       | x              |
       | label:relation |
     When get answers of typeql get
       """
-      match $x sub attribute;
+      match $x sub attribute; get;
       """
     Then uniquely identify answer concepts
       | x               |
@@ -1727,7 +1738,7 @@ Feature: TypeQL Undefine Query
       | label:attribute |
     When get answers of typeql get
       """
-      match $x sub relation:role;
+      match $x sub relation:role; get;
       """
     Then uniquely identify answer concepts
       | x                   |

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -46,7 +46,7 @@ Feature: TypeQL Undefine Query
   ################
 
   Scenario: calling 'undefine' with 'sub entity' on a subtype of 'entity' deletes it
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub entity;
       """
@@ -62,7 +62,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub entity;
       """
@@ -87,7 +87,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     When session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub person;
       """
@@ -102,7 +102,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub person;
       """
@@ -119,7 +119,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub person;
       """
@@ -135,7 +135,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub person;
       """
@@ -173,7 +173,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type child; $x plays employment:employee;
       """
@@ -195,7 +195,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type child; $x owns name;
       """
@@ -217,14 +217,14 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type child; $x owns email @key;
       """
     Then answer size is: 0
 
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub entity;
       """
@@ -274,7 +274,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub entity;
       """
@@ -289,7 +289,7 @@ Feature: TypeQL Undefine Query
   ##################
 
   Scenario: undefining a relation type removes it
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub relation;
       """
@@ -304,7 +304,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub relation;
       """
@@ -324,7 +324,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match contract-employment plays $x;
       """
@@ -338,7 +338,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match contract-employment plays $x;
       """
@@ -356,7 +356,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x owns start-date;
       """
@@ -371,7 +371,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns start-date;
       """
@@ -389,7 +389,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x owns employment-reference @key;
       """
@@ -404,7 +404,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns employment-reference @key;
       """
@@ -437,7 +437,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: all existing instances of a relation type must be deleted in order to undefine it
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub relation;
       """
@@ -486,7 +486,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub relation;
       """
@@ -496,7 +496,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining a relation type automatically detaches any possible roleplayers
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match
         $x type person;
@@ -512,7 +512,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type person;
@@ -526,7 +526,7 @@ Feature: TypeQL Undefine Query
   #############################
 
   Scenario: a role type can be removed from its relation type
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match employment relates $x;
       """
@@ -541,7 +541,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match employment relates $x;
       """
@@ -558,7 +558,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays employment:employee;
       """
@@ -602,7 +602,7 @@ Feature: TypeQL Undefine Query
     When connection close all sessions
     When connection open data session for database: typedb
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x relates employee;
       """
@@ -627,7 +627,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining a role type automatically detaches any possible roleplayers
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match
         $x type person;
@@ -643,7 +643,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type person;
@@ -703,7 +703,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match employment relates $x;
       """
@@ -727,7 +727,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x type part-time; $x relates $role;
       """
@@ -780,7 +780,7 @@ Feature: TypeQL Undefine Query
     When connection close all sessions
     When connection open data session for database: typedb
     When session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x plays employment:employee;
       """
@@ -795,7 +795,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining a playable role that was not actually playable to begin with throws
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match person plays $x;
       """
@@ -857,7 +857,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x type <attr>;
       """
@@ -869,7 +869,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x type <attr>;
       """
@@ -900,7 +900,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa email;
       """
@@ -918,7 +918,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match first-name plays $x;
       """
@@ -932,7 +932,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match first-name plays $x;
       """
@@ -950,7 +950,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x owns locale;
       """
@@ -965,7 +965,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns locale;
       """
@@ -983,7 +983,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x owns name-id @key;
       """
@@ -998,7 +998,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns name-id @key;
       """
@@ -1023,7 +1023,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    Then typeql match; throws exception
+    Then typeql get; throws exception
       """
       match $x type name;
       """
@@ -1037,7 +1037,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: all existing instances of an attribute type must be deleted in order to undefine it
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub attribute;
       """
@@ -1085,7 +1085,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub attribute;
       """
@@ -1100,7 +1100,7 @@ Feature: TypeQL Undefine Query
   ########################
 
   Scenario: undefining an attribute ownership removes it
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match
         $x owns name;
@@ -1116,7 +1116,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x owns name;
@@ -1154,7 +1154,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns email;
       """
@@ -1176,7 +1176,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: when a type can own an attribute, but none of its instances actually do, the ownership can be undefined
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x owns name;
       """
@@ -1204,7 +1204,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x owns name;
       """
@@ -1301,7 +1301,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: read
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match
         $x has name $n;
@@ -1320,7 +1320,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x has name $n;
@@ -1356,7 +1356,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match
         $x has name $n;
@@ -1370,7 +1370,7 @@ Feature: TypeQL Undefine Query
       undefine rule samuel-email-rule;
       """
 
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x has name $n;
@@ -1484,7 +1484,7 @@ Feature: TypeQL Undefine Query
   ############
 
   Scenario: undefining a type as abstract converts an abstract to a concrete type, allowing creation of instances
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match
         $x type abstract-type;
@@ -1511,7 +1511,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type abstract-type;
@@ -1527,7 +1527,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa abstract-type;
       """
@@ -1542,7 +1542,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type person;
@@ -1568,7 +1568,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type abstract-type;
@@ -1598,7 +1598,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
         $x type vehicle-registration;
@@ -1612,7 +1612,7 @@ Feature: TypeQL Undefine Query
   ###################
 
   Scenario: a type and an attribute type that it owns can be removed simultaneously
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub entity;
       """
@@ -1621,7 +1621,7 @@ Feature: TypeQL Undefine Query
       | label:person        |
       | label:abstract-type |
       | label:entity        |
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub attribute;
       """
@@ -1639,7 +1639,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub entity;
       """
@@ -1647,7 +1647,7 @@ Feature: TypeQL Undefine Query
       | x                   |
       | label:abstract-type |
       | label:entity        |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub attribute;
       """
@@ -1657,7 +1657,7 @@ Feature: TypeQL Undefine Query
       | label:attribute |
 
   Scenario: a type, a relation type that it plays in and an attribute type that it owns can be removed simultaneously
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub entity;
       """
@@ -1666,7 +1666,7 @@ Feature: TypeQL Undefine Query
       | label:person        |
       | label:abstract-type |
       | label:entity        |
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub relation;
       """
@@ -1674,7 +1674,7 @@ Feature: TypeQL Undefine Query
       | x                |
       | label:employment |
       | label:relation   |
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub attribute;
       """
@@ -1683,7 +1683,7 @@ Feature: TypeQL Undefine Query
       | label:name      |
       | label:email     |
       | label:attribute |
-    Given get answers of typeql match
+    Given get answers of typeql get
       """
       match $x sub relation:role;
       """
@@ -1702,7 +1702,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub entity;
       """
@@ -1710,14 +1710,14 @@ Feature: TypeQL Undefine Query
       | x                   |
       | label:abstract-type |
       | label:entity        |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub relation;
       """
     Then uniquely identify answer concepts
       | x              |
       | label:relation |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub attribute;
       """
@@ -1725,7 +1725,7 @@ Feature: TypeQL Undefine Query
       | x               |
       | label:email     |
       | label:attribute |
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x sub relation:role;
       """

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -103,7 +103,7 @@ Feature: TypeQL Update Query
       """
     Then transaction commits
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match $x isa person, has name $n;
       """
@@ -213,7 +213,7 @@ Feature: TypeQL Update Query
       """
     Then transaction commits
     When session opens transaction of type: read
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       (named: $p, name: $nc) isa naming;
@@ -228,7 +228,7 @@ Feature: TypeQL Update Query
       | key:ref:4 | attr:name:Alex     |
       | key:ref:5 | attr:name:Bob      |
 
-    When get answers of typeql match
+    When get answers of typeql get
       """
       match
       $p isa person;

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -69,7 +69,7 @@ Feature: TypeQL Update Query
       delete $x has name "Alex";
       insert $x has name "Bob";
       """
-    Then session transaction closes
+    Given session transaction closes
     Given session opens transaction of type: write
     Then typeql update; throws exception
       """

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -105,7 +105,7 @@ Feature: TypeQL Update Query
     When session opens transaction of type: read
     When get answers of typeql get
       """
-      match $x isa person, has name $n;
+      match $x isa person, has name $n; get;
       """
     Then uniquely identify answer concepts
       | x         | n               |
@@ -218,6 +218,7 @@ Feature: TypeQL Update Query
       match
       (named: $p, name: $nc) isa naming;
       $nc has name $n;
+      get;
       """
     Then uniquely identify answer concepts
       | p         | n                  |
@@ -233,6 +234,7 @@ Feature: TypeQL Update Query
       match
       $p isa person;
       $p has name $n;
+      get;
       """
     Then answer size is: 0
 

--- a/query/reasoner/attribute-attachment.feature
+++ b/query/reasoner/attribute-attachment.feature
@@ -73,14 +73,14 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person, has string-attribute $y;
+      match $x isa person, has string-attribute $y; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x isa string-attribute;
+      match $x isa string-attribute; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -115,7 +115,7 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has string-attribute $y;
+      match $x has string-attribute $y; get;
       """
     Then verify answer size is: 3
     Then verify answers are sound
@@ -150,21 +150,21 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has retailer 'Ocado';
+      match $x has retailer 'Ocado'; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x has retailer $r;
+      match $x has retailer $r; get;
       """
     Then verify answer size is: 4
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x has retailer 'Tesco';
+      match $x has retailer 'Tesco'; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -193,7 +193,7 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa soft-drink, has retailer 'Ocado';
+      match $x isa soft-drink, has retailer 'Ocado'; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -223,7 +223,7 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has retailer 'Tesco';
+      match $x has retailer 'Tesco'; get;
       """
     Then verify answer size is: 3
     Then verify answers are sound
@@ -260,7 +260,7 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has retailer 'Tesco';
+      match $x has retailer 'Tesco'; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -292,21 +292,21 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has age > 20;
+      match $x has age > 20; get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x has age > 5;
+      match $x has age > 5; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x has age > 5; $x has age < 8;
+      match $x has age > 5; $x has age < 8; get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -337,7 +337,7 @@ Feature: Attribute Attachment Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has age-in-days $days;
+      match $x has age-in-days $days; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound

--- a/query/reasoner/compound-queries.feature
+++ b/query/reasoner/compound-queries.feature
@@ -69,6 +69,7 @@ Feature: Compound Query Resolution
       match
         $x has base-attribute $ax;
         $y has base-attribute $ay;
+      get;
       """
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/concept-inequality.feature
+++ b/query/reasoner/concept-inequality.feature
@@ -104,14 +104,14 @@ Feature: Concept Inequality Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (state: $s) isa holds;
+      match (state: $s) isa holds; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
       """
-      match $s isa state, has name 's2';
+      match $s isa state, has name 's2'; get;
       """
 
 
@@ -119,7 +119,7 @@ Feature: Concept Inequality Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (ball1: $x, ball2: $y) isa selection;
+      match (ball1: $x, ball2: $y) isa selection; get;
       """
     # materialised: [ab, ba, bc, cb]
     # inferred: [aa, ac, bb, ca, cc]
@@ -131,6 +131,7 @@ Feature: Concept Inequality Resolution
       match
         (ball1: $x, ball2: $y) isa selection;
         not { $x is $y; };
+      get;
       """
     # materialised: [ab, ba, bc, cb]
     # inferred: [ac, ca]
@@ -161,6 +162,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $y) isa selection;
         not { $x is $y; };
         $y has name 'c';
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -173,6 +175,7 @@ Feature: Concept Inequality Resolution
         not { $x is $y; };
         $y has name 'c';
         {$x has name 'a';} or {$x has name 'b';};
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -197,6 +200,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $y) isa selection;
         (ball1: $x, ball2: $z) isa selection;
         not { $y is $z; };
+      get;
       """
     # [aab, aac, aba, abc, aca, acb,
     #  bab, bac, bba, bbc, bca, bcb,
@@ -239,6 +243,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $y) isa selection;
         (ball1: $y, ball2: $z) isa selection;
         not { $x is $z; };
+      get;
       """
     Then verify answer size is: 18
     Then verify answers are sound
@@ -283,6 +288,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $z1) isa selection;
         (ball1: $x, ball2: $y2) isa selection;
         (ball1: $x, ball2: $z2) isa selection;
+      get;
       """
     # For each of the [3] values of $x, there are 3^4 = 81 choices for {$y1, $z1, $y2, $z2}, for a total of 243
     Then verify answer size is: 243
@@ -298,6 +304,7 @@ Feature: Concept Inequality Resolution
 
         not { $y1 is $z1; };
         not { $y2 is $z2; };
+      get;
       """
     Then verify answer size is: 108
     # Each neq predicate reduces the answer size by 1/3, cutting it to 162, then 108
@@ -344,6 +351,7 @@ Feature: Concept Inequality Resolution
         (ball1: $x, ball2: $y) isa selection;
         (ball1: $x, ball2: $z1) isa selection;
         (ball1: $y, ball2: $z2) isa selection;
+      get;
       """
     # There are 3^4 possible choices for the set {$x, $y, $z1, $z2}, for a total of 81
     Then verify answer size is: 81
@@ -358,6 +366,7 @@ Feature: Concept Inequality Resolution
 
         not { $x is $z1; };
         not { $y is $z2; };
+      get;
       """
     # Each neq predicate reduces the answer size by 1/3, cutting it to 54, then 36
     Then verify answer size is: 36
@@ -423,6 +432,7 @@ Feature: Concept Inequality Resolution
         $ax isa! $typeof_ax;
         $ay isa! $typeof_ay;
         not { $typeof_ax is $typeof_ay; };
+      get;
       """
     # x   | ax  | y   | ay  |
     # PER | STA | SOF | NAM |

--- a/query/reasoner/negation.feature
+++ b/query/reasoner/negation.feature
@@ -78,7 +78,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then verify answer size is: 5
     Given reasoning query
@@ -88,6 +88,7 @@ Feature: Negation Resolution
         not {
           $e (employee: $x) isa employment;
         };
+      get;
       """
     Then verify answer size is: 3
 
@@ -108,7 +109,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then verify answer size is: 5
     Given reasoning query
@@ -118,6 +119,7 @@ Feature: Negation Resolution
         not {
           ($x) isa relation;
         };
+      get;
       """
     Then verify answer size is: 3
 
@@ -135,7 +137,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then verify answer size is: 5
     Given reasoning query
@@ -145,6 +147,7 @@ Feature: Negation Resolution
         not {
           $x has name $val;
         };
+      get;
       """
     Then verify answer size is: 2
 
@@ -162,7 +165,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then verify answer size is: 5
     Given reasoning query
@@ -172,6 +175,7 @@ Feature: Negation Resolution
         not {
           $x has name "Bob";
         };
+      get;
       """
     Then verify answer size is: 4
 
@@ -190,6 +194,7 @@ Feature: Negation Resolution
       match
         $x has age $y;
         not {$y 20;};
+      get;
       """
     Then verify answer size is: 1
     Then verify answer set is equivalent for query
@@ -197,6 +202,7 @@ Feature: Negation Resolution
       match
         $x has age $y;
         $y 10;
+      get;
       """
 
 
@@ -215,11 +221,12 @@ Feature: Negation Resolution
       match
         $x has attribute $y;
         not {$y isa name;};
+      get;
       """
     Then verify answer size is: 2
     Then verify answer set is equivalent for query
       """
-      match $x has age $y;
+      match $x has age $y; get;
       """
 
 
@@ -250,6 +257,7 @@ Feature: Negation Resolution
         (friend: $a, friend: $b) isa friendship;
         (friend: $b, friend: $c) isa friendship;
         (friend: $c, friend: $d) isa friendship;
+      get;
       """
     # abab, abcb, abcd,
     # baba, babc, bcba, bcbc, bcdc, bcdz,
@@ -264,6 +272,7 @@ Feature: Negation Resolution
         (friend: $b, friend: $c) isa friendship;
         (friend: $c, friend: $d) isa friendship;
         not {$c isa dog;};
+      get;
       """
     # Eliminates (cdzd, zdzd)
     Then verify answer size is: 22
@@ -274,6 +283,7 @@ Feature: Negation Resolution
         (friend: $b, friend: $c) isa friendship;
         (friend: $c, friend: $d) isa friendship;
         $c isa person;
+      get;
       """
 
 
@@ -303,6 +313,7 @@ Feature: Negation Resolution
       match
         (friend: $a, friend: $b) isa friendship;
         (friend: $b, friend: $c) isa friendship;
+      get;
       """
     # aba, abc
     # bab, bcb, bcd
@@ -317,6 +328,7 @@ Feature: Negation Resolution
         not {(friend: $b, friend: $z) isa friendship;};
         (friend: $b, friend: $c) isa friendship;
         $z isa dog;
+      get;
       """
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
     Then verify answer size is: 10
@@ -327,6 +339,7 @@ Feature: Negation Resolution
         (friend: $b, friend: $c) isa friendship;
         $z isa dog;
         not {$b has name "d";};
+      get;
       """
 
 
@@ -342,7 +355,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
     """
-      match ($r1: $x) isa employment;
+      match ($r1: $x) isa employment; get;
       """
     # r1       | x   |
     # role     | PER |
@@ -355,6 +368,7 @@ Feature: Negation Resolution
       match
         ($r1: $x) isa employment;
         not {$r1 type relation:role;};
+      get;
       """
     Then verify answer size is: 2
 
@@ -373,7 +387,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has attribute $r;
+      match $x has attribute $r; get;
       """
     Then verify answer size is: 8
     Given reasoning query
@@ -383,6 +397,7 @@ Feature: Negation Resolution
         not {
           $x isa person, has name "Tim", has age 55;
         };
+      get;
       """
     Then verify answer size is: 6
     Then verify answer set is equivalent for query
@@ -394,6 +409,7 @@ Feature: Negation Resolution
           $x has name "Tim";
           $x has age 55;
         };
+      get;
       """
 
 
@@ -411,7 +427,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has attribute $r;
+      match $x has attribute $r; get;
       """
     Then verify answer size is: 8
     Given reasoning query
@@ -419,6 +435,7 @@ Feature: Negation Resolution
       match
         $x has attribute $r;
         not { $x isa company; };
+      get;
       """
     Then verify answer size is: 7
     Given reasoning query
@@ -427,6 +444,7 @@ Feature: Negation Resolution
         $x has attribute $r;
         not { $x isa company; };
         not { $x has name "Tim"; };
+      get;
       """
     Then verify answer size is: 3
     Given reasoning query
@@ -436,6 +454,7 @@ Feature: Negation Resolution
         not { $x isa company; };
         not { $x has name "Tim"; };
         not { $r 55; };
+      get;
       """
     Then verify answer size is: 2
 
@@ -463,7 +482,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then verify answer size is: 4
     Given reasoning query
@@ -474,6 +493,7 @@ Feature: Negation Resolution
           (employee: $x, employer: $y) isa employment;
           $y isa pizza-company;
         };
+      get;
       """
     Then verify answer size is: 3
 
@@ -507,6 +527,7 @@ Feature: Negation Resolution
           (employee: $x, employer: $y) isa employment;
           $y isa company;
         };
+      get;
       """
     Then verify answer size is: 2
 
@@ -541,6 +562,7 @@ Feature: Negation Resolution
           (employee: $x, employer: $y) isa employment;
           $y isa pizza-company;
         };
+      get;
       """
     Then verify answer size is: 3
 
@@ -583,6 +605,7 @@ Feature: Negation Resolution
       match
         $continent isa continent;
         $area isa area;
+      get;
       """
     Then verify answer size is: 1
     Given reasoning query
@@ -591,6 +614,7 @@ Feature: Negation Resolution
         $continent isa continent;
         $area isa area;
         not {(superior: $continent, subordinate: $area) isa location-hierarchy;};
+      get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -662,6 +686,7 @@ Feature: Negation Resolution
       match
         (from: $x, to: $y) isa indirect-link;
         $x has index "aa";
+      get;
       """
     Then verify answer size is: 2
     Then verify answer set is equivalent for query
@@ -670,6 +695,7 @@ Feature: Negation Resolution
         (from: $x, to: $y) isa reachable;
         $x has index "aa";
         not {$y has index "bb";};
+      get;
       """
 
 
@@ -700,14 +726,14 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has name "Not Ten", has age 20;
+      match $x has name "Not Ten", has age 20; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x has name "Not Ten", has age 10;
+      match $x has name "Not Ten", has age 10; get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -737,14 +763,14 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person;
+      match $x isa person; get;
       """
     Then verify answer size is: 3
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match $x isa person, has name "No Age";
+      match $x isa person, has name "No Age"; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -790,7 +816,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa company;
+      match $x isa company; get;
       """
     Then verify answer size is: 4
     Given reasoning query
@@ -798,6 +824,7 @@ Feature: Negation Resolution
       match
         $x isa company;
         not { (not-in-uk: $x) isa non-uk; };
+      get;
       """
     # Should exclude both the company in France and the company with no country
     Then verify answer size is: 2
@@ -816,6 +843,7 @@ Feature: Negation Resolution
       match
         $x isa company;
         { $x has name "a"; } or { $x has name "b"; };
+      get;
       """
 
 
@@ -866,6 +894,7 @@ Feature: Negation Resolution
             $x has name "c";
           };
         };
+      get;
       """
     Then verify answer size is: 3
     Then verify answer set is equivalent for query
@@ -873,6 +902,7 @@ Feature: Negation Resolution
       match
         $x isa company;
         not { $x has name "d"; };
+      get;
       """
 
 
@@ -971,7 +1001,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
+      match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis; get;
       """
     Then verify answer size is: 0
     Then verify answers are consistent across 5 executions
@@ -1046,7 +1076,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role-3: $x, role-4: $y) isa relation-4;
+      match (role-3: $x, role-4: $y) isa relation-4; get;
       """
     Then verify answer size is: 11
     Then verify answers are consistent across 5 executions
@@ -1127,6 +1157,7 @@ Feature: Negation Resolution
       match
         (from: $x, to: $y) isa unreachable;
         $x has index "aa";
+      get;
       """
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
     Then verify answer size is: 5
@@ -1138,6 +1169,7 @@ Feature: Negation Resolution
         $x has index "aa"; $y isa node;
         { $y has index "aa"; } or { $y has index "ee"; } or { $y has index "ff"; } or
         { $y has index "gg"; } or { $y has index "hh"; };
+      get;
       """
 
   Scenario: negated and non-negated clauses can use the same rule
@@ -1168,6 +1200,7 @@ Feature: Negation Resolution
       match
         $x has retailer $r;
         not { $r == "Ocado"; };
+      get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -1198,7 +1231,7 @@ Feature: Negation Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $p isa person; not { ($p, $f) isa enemies; };
+      match $p isa person; not { ($p, $f) isa enemies; }; get;
       """
     Then verify answer size is: 0
 #    TODO: Add a case with non-zero answers

--- a/query/reasoner/recursion.feature
+++ b/query/reasoner/recursion.feature
@@ -98,7 +98,7 @@ Feature: Recursion Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (subordinate: $x, superior: $y) isa big-location-hierarchy;
+      match (subordinate: $x, superior: $y) isa big-location-hierarchy; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -167,7 +167,7 @@ Feature: Recursion Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role31: $x, role32: $y) isa relation3;
+      match (role31: $x, role32: $y) isa relation3; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -230,7 +230,7 @@ Feature: Recursion Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role31: $x, role32: $y) isa relation3;
+      match (role31: $x, role32: $y) isa relation3; get;
       """
     # Each of the two material relation1 instances should infer a single relation3 via 1-to-2 and 2-to-3
     Then verify answer size is: 2
@@ -238,7 +238,7 @@ Feature: Recursion Resolution
     Then verify answers are complete
     Given reasoning query
       """
-      match (role21: $x, role22: $y) isa relation2;
+      match (role21: $x, role22: $y) isa relation2; get;
       """
     # Relation-3-to-2 should not make any additional inferences - it should merely assert that the relations exist
     Then verify answer size is: 2
@@ -275,7 +275,7 @@ Feature: Recursion Resolution
       """
     Given reasoning query
       """
-      match $x isa dream; limit 10;
+      match $x isa dream; get; limit 10;
       """
     Then verify answer size is: 10
 
@@ -365,14 +365,14 @@ Feature: Recursion Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $p isa pair, has name 'ff';
+      match $p isa pair, has name 'ff'; get;
       """
     Then verify answer size is: 16
     Then verify answers are sound
     # Then verify answers are complete  # Not yet supported
     Given reasoning query
       """
-      match $p isa pair;
+      match $p isa pair; get;
       """
     Then verify answer size is: 64
     Then verify answers are sound
@@ -572,7 +572,7 @@ Feature: Recursion Resolution
       """
     Given reasoning query
       """
-      match (ancestor: $X, descendant: $Y) isa ancestorship;
+      match (ancestor: $X, descendant: $Y) isa ancestorship; get;
       """
     Then verify answer size is: 10
     Then verify answers are sound
@@ -591,7 +591,7 @@ Feature: Recursion Resolution
       """
     Given reasoning query
       """
-      match ($X, $Y) isa ancestorship;
+      match ($X, $Y) isa ancestorship; get;
       """
     Then verify answer size is: 20
     Then verify answers are sound
@@ -873,7 +873,7 @@ Feature: Recursion Resolution
     Then verify answers are complete
     Then verify answer set is equivalent for query
       """
-      match $x has index 'a2';
+      match $x has index 'a2'; get;
       """
 
 
@@ -955,7 +955,7 @@ Feature: Recursion Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (from: $x, to: $y) isa reachable;
+      match (from: $x, to: $y) isa reachable; get;
       """
     Then verify answer size is: 7
     Then verify answers are sound
@@ -1230,7 +1230,7 @@ Feature: Recursion Resolution
       """
     Given reasoning query
       """
-      match (from: $x, to: $y) isa RevSG;
+      match (from: $x, to: $y) isa RevSG; get;
       """
     Then verify answer size is: 11
     Then verify answers are sound
@@ -1620,7 +1620,7 @@ Feature: Recursion Resolution
     Then verify answers are complete
     Then verify answer set is equivalent for query
       """
-      match $y isa b-entity;
+      match $y isa b-entity; get;
       """
 
 
@@ -1771,5 +1771,5 @@ Feature: Recursion Resolution
 
     Then verify answer set is equivalent for query
       """
-      match $y isa a-entity;
+      match $y isa a-entity; get;
       """

--- a/query/reasoner/relation-inference.feature
+++ b/query/reasoner/relation-inference.feature
@@ -82,6 +82,7 @@ Feature: Relation Inference Resolution
       match
         $x isa person;
         ($x) isa employment;
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -110,6 +111,7 @@ Feature: Relation Inference Resolution
       match
         $x has name "Haikal";
         ($x) isa employment;
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -119,6 +121,7 @@ Feature: Relation Inference Resolution
       match
         $x has name "Michael";
         ($x) isa employment;
+      get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -153,6 +156,7 @@ Feature: Relation Inference Resolution
         $i isa item, has name $n;
         $n "3kg jar of Nutella" isa name;
         $p 14.99 isa price;
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -187,6 +191,7 @@ Feature: Relation Inference Resolution
       match
         $x 1664 isa year;
         ($x, employee: $p, employer: $y) isa employment;
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -221,7 +226,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $r isa friendship;
+      match $r isa friendship; get;
       """
     # When there is 1 concept we have {aa}.
     # Adding a 2nd concept gives us 2 new relations - where each relation contains b, and one other concept (a or b).
@@ -255,7 +260,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match ($x, $y) isa friendship;
+      match ($x, $y) isa friendship; get;
       """
     # Here there are n choices for x, and n choices for y, so the total answer size is n^2
     Then verify answer size is: 25
@@ -284,7 +289,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (employee: $x, employer: $x) isa employment;
+      match (employee: $x, employer: $x) isa employment; get;
       """
     Then verify answer size is: 3
     Then verify answers are sound
@@ -310,7 +315,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (employee: $x, employer: $y) isa employment;
+      match (employee: $x, employer: $y) isa employment; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -338,7 +343,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (employee: $x, employer: $x) isa employment;
+      match (employee: $x, employer: $x) isa employment; get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -397,7 +402,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (coworker: $x, coworker: $x) isa coworkers;
+      match (coworker: $x, coworker: $x) isa coworkers; get;
       """
     # (p,p) is a coworkers since people work with themselves.
     # Applying the robot work rule we see that (r1,p) is a pet ownership, and (p,p) and (p,r2) are coworker relations,
@@ -410,7 +415,7 @@ Feature: Relation Inference Resolution
     Then verify answers are complete
     Given reasoning query
       """
-      match (coworker: $x, coworker: $y) isa coworkers;
+      match (coworker: $x, coworker: $y) isa coworkers; get;
       """
     # $x | $y |
     # p  | p  |
@@ -453,7 +458,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa location-hierarchy;
+      match $x isa location-hierarchy; get;
       """
     Then verify answer size is: 3
     Then verify answers are sound
@@ -486,7 +491,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (subordinate: $x1, superior: $x2) isa location-hierarchy;
+      match (subordinate: $x1, superior: $x2) isa location-hierarchy; get;
       """
     Then verify answer size is: 6
     Then verify answers are consistent across 5 executions
@@ -547,7 +552,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (subordinate: $x, superior: $y) isa location-hierarchy;
+      match (subordinate: $x, superior: $y) isa location-hierarchy; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -578,7 +583,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (employee: $x, employee: $y) isa employment;
+      match (employee: $x, employee: $y) isa employment; get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -605,7 +610,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (employee: $x) isa employment;
+      match (employee: $x) isa employment; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -634,7 +639,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (friend: $a, friend: $b, friend: $c) isa friendship;
+      match (friend: $a, friend: $b, friend: $c) isa friendship; get;
       """
     Then verify answer size is: 6
     Then verify answers are sound
@@ -682,6 +687,7 @@ Feature: Relation Inference Resolution
         (choice1: $x, choice2: $y) isa selection;
         $x has name $n;
         $y has name $n;
+      get;
       """
     # (a,a), (b,b), (c,c)
     Then verify answer size is: 3
@@ -705,6 +711,7 @@ Feature: Relation Inference Resolution
         (choice1: $x, choice2: $y) isa selection;
         $x has name 'a';
         $y has name 'a';
+      get;
       """
 
 
@@ -741,6 +748,7 @@ Feature: Relation Inference Resolution
         ($a, $b);
         $b isa place, has name "Turku";
         ($b, $c);
+      get;
       """
     # $c in {'Turku Airport', 'Finland'}
     Then verify answer size is: 2
@@ -776,6 +784,7 @@ Feature: Relation Inference Resolution
         $a isa place, has name "Turku Airport";
         ($a, $b);
         $b isa place, has name "Turku";
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -787,6 +796,7 @@ Feature: Relation Inference Resolution
         ($a, $b);
         $b isa place, has name "Turku";
         ($c, $d);
+      get;
       """
     # (2 db relations + 1 inferred) x 2 for variable swap
     Then verify answer size is: 6
@@ -829,7 +839,7 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match ($a, $b) isa relation;
+      match ($a, $b) isa relation; get;
       """
     Then verify answers are sound
     Then verify answers are complete
@@ -838,7 +848,7 @@ Feature: Relation Inference Resolution
     Then verify answer size is: 6
     Then verify answer set is equivalent for query
       """
-      match ($a, $b);
+      match ($a, $b); get;
       """
 
   Scenario: conjunctions of untyped reasoned relations are correctly resolved
@@ -868,6 +878,7 @@ Feature: Relation Inference Resolution
       match
         ($a, $b);
         ($b, $c);
+      get;
       """
     # a   | b   | c   |
     # AIR | TUR | FIN |
@@ -931,21 +942,21 @@ Feature: Relation Inference Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match ($x) isa derivedRelation;
+      match ($x) isa derivedRelation; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match ($x) isa! derivedRelation;
+      match ($x) isa! derivedRelation; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match ($x) isa directDerivedRelation;
+      match ($x) isa directDerivedRelation; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound

--- a/query/reasoner/rule-interaction.feature
+++ b/query/reasoner/rule-interaction.feature
@@ -103,7 +103,7 @@ Feature: Rule Interaction Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person, has name $n, has tag "P";
+      match $x isa person, has name $n, has tag "P"; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -156,7 +156,7 @@ Feature: Rule Interaction Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa person, has name 'tracey';
+      match $x isa person, has name 'tracey'; get;
       """
     Then verify answer size is: 2
     Then verify answers are sound

--- a/query/reasoner/schema-queries.feature
+++ b/query/reasoner/schema-queries.feature
@@ -82,23 +82,23 @@ Feature: Schema Query Resolution (Variable Types)
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa entity;
+      match $x isa entity; get;
       """
     Then verify answer size is: 3
     Given reasoning query
       """
-      match $x isa relation;
+      match $x isa relation; get;
       """
     # (xx, yy, zz, xy, xz, yz)
     Then verify answer size is: 6
     Given reasoning query
       """
-      match $x isa attribute;
+      match $x isa attribute; get;
       """
     Then verify answer size is: 1
     Given reasoning query
       """
-      match $x isa $type;
+      match $x isa $type; get;
       """
     # 3 people x 3 types of person {person,entity,thing}
     # 6 friendships x 3 types of friendship {friendship, relation, thing}
@@ -131,13 +131,13 @@ Feature: Schema Query Resolution (Variable Types)
     Given verifier is initialised
     Given reasoning query
       """
-      match ($u, $v) isa relation;
+      match ($u, $v) isa relation; get;
       """
     # (xx, yy, zz, xy, xz, yz, yx, zx, zy)
     Then verify answer size is: 9
     Given reasoning query
       """
-      match ($u, $v) isa $type;
+      match ($u, $v) isa $type; get;
       """
     # 3 possible $u x 3 possible $v x 3 possible $type {friendship,relation,thing}
     Then verify answer size is: 27
@@ -189,7 +189,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa relation;
+      match $x isa relation; get;
       """
     Then verify answer size is: 6
     Then verify answers are sound
@@ -199,6 +199,7 @@ Feature: Schema Query Resolution (Variable Types)
       match
         $x isa $type;
         $type owns contract;
+      get;
       """
     # friendship can't have a contract... at least, not in this pristine test world
     # note: enforcing 'has contract' also eliminates 'relation' and 'thing' as possible types
@@ -234,7 +235,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa relation;
+      match $x isa relation; get;
       """
     # 3 friendships, 3 employments
     Then verify answer size is: 6
@@ -243,6 +244,7 @@ Feature: Schema Query Resolution (Variable Types)
       match
         $x isa $type;
         $type sub relation;
+      get;
       """
     # 3 friendships, 3 employments, 6 relations
     Then verify answer size is: 12
@@ -294,7 +296,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given verifier is initialised
     Given reasoning query
       """
-      match $x isa relation;
+      match $x isa relation; get;
       """
     Then verify answer size is: 6
     Then verify answers are sound
@@ -304,6 +306,7 @@ Feature: Schema Query Resolution (Variable Types)
       match
         $x isa $type;
         $type plays legal-documentation:subject;
+      get;
       """
     # friendship can't be a documented-thing
     # note: enforcing 'plays legal-documentation:subject' also eliminates 'relation' and 'thing' as possible types
@@ -342,7 +345,7 @@ Feature: Schema Query Resolution (Variable Types)
     Given verifier is initialised
     Given reasoning query
       """
-      match (employee: $x, employer: $y) isa employment;
+      match (employee: $x, employer: $y) isa employment; get;
       """
     Then verify answer size is: 3
     Then verify answers are sound
@@ -352,6 +355,7 @@ Feature: Schema Query Resolution (Variable Types)
       match
         (employee: $x, employer: $y) isa employment;
         $x isa $type;
+      get;
       """
     # 3 colonels * 5 supertypes of colonel (colonel, military-person, person, entity, thing)
     Then verify answer size is: 15
@@ -362,6 +366,7 @@ Feature: Schema Query Resolution (Variable Types)
       match
         ($x, $y) isa employment;
         $x isa $type;
+      get;
       """
     # (3 colonels * 5 supertypes of colonel * 1 company)
     # + (1 company * 3 supertypes of company * 3 colonels)
@@ -458,6 +463,7 @@ Feature: Schema Query Resolution (Variable Types)
         $p isa person;
         ($p) isa $f;
         $f type relation;
+      get;
       """
     Then verify answer size is: 1
 
@@ -482,5 +488,6 @@ Feature: Schema Query Resolution (Variable Types)
         $p isa person;
         ($role: $p) isa friendship;
         $role type relation:role;
+      get;
       """
     Then verify answer size is: 1

--- a/query/reasoner/type-hierarchy.feature
+++ b/query/reasoner/type-hierarchy.feature
@@ -75,6 +75,7 @@ Feature: Type Hierarchy Resolution
         $x isa person;
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
+      get;
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then verify answer size is: 2
@@ -87,6 +88,7 @@ Feature: Type Hierarchy Resolution
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
         $y has name 'a';
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -97,6 +99,7 @@ Feature: Type Hierarchy Resolution
         $x isa person;
         $y isa child;
         (actor: $x, writer: $y) isa film-production;
+      get;
       """
     # Answer is (actor:$x, writer:$v) ONLY
     Then verify answer size is: 1
@@ -109,6 +112,7 @@ Feature: Type Hierarchy Resolution
         $y isa child;
         (actor: $x, writer: $y) isa film-production;
         $y has name 'a';
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -119,6 +123,7 @@ Feature: Type Hierarchy Resolution
         $x isa child;
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
+      get;
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then verify answer size is: 2
@@ -131,6 +136,7 @@ Feature: Type Hierarchy Resolution
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
         $y has name 'a';
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -173,13 +179,13 @@ Feature: Type Hierarchy Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (child: $x, father: $y) isa large-family;
+      match (child: $x, father: $y) isa large-family; get;
       """
     Then verify answer size is: 0
     # Matching two siblings when only one is present
     Given reasoning query
       """
-      match (mother: $x, father: $y) isa large-family;
+      match (mother: $x, father: $y) isa large-family; get;
       """
     Then verify answer size is: 0
     Then verify answers are sound
@@ -228,7 +234,7 @@ Feature: Type Hierarchy Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (scifi-writer:$x, scifi-actor:$y) isa film-production;
+      match (scifi-writer:$x, scifi-actor:$y) isa film-production; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -277,7 +283,7 @@ Feature: Type Hierarchy Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (writer:$x, actor:$y) isa scifi-production;
+      match (writer:$x, actor:$y) isa scifi-production; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -326,7 +332,7 @@ Feature: Type Hierarchy Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (writer:$x, actor:$y) isa film-production;
+      match (writer:$x, actor:$y) isa film-production; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -394,6 +400,7 @@ Feature: Type Hierarchy Resolution
         $x isa person;
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
+      get;
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then verify answer size is: 2
@@ -406,6 +413,7 @@ Feature: Type Hierarchy Resolution
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
         $y has name 'a';
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -416,6 +424,7 @@ Feature: Type Hierarchy Resolution
         $x isa person;
         $y isa child;
         (actor: $x, writer: $y) isa film-production;
+      get;
       """
     # Answer is (actor:$x, writer:$v) ONLY
     Then verify answer size is: 1
@@ -428,6 +437,7 @@ Feature: Type Hierarchy Resolution
         $y isa child;
         (actor: $x, writer: $y) isa film-production;
         $y has name 'a';
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -438,6 +448,7 @@ Feature: Type Hierarchy Resolution
         $x isa child;
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
+      get;
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
     Then verify answer size is: 2
@@ -450,6 +461,7 @@ Feature: Type Hierarchy Resolution
         $y isa person;
         (actor: $x, writer: $y) isa film-production;
         $y has name 'a';
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -497,7 +509,7 @@ Feature: Type Hierarchy Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (home-owner: $x, resident: $y) isa residence;
+      match (home-owner: $x, resident: $y) isa residence; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -507,6 +519,7 @@ Feature: Type Hierarchy Resolution
       match
         (home-owner: $x, resident: $y) isa residence;
         (parent-home-owner: $x, child-resident: $y) isa family-residence;
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound

--- a/query/reasoner/value-predicate.feature
+++ b/query/reasoner/value-predicate.feature
@@ -71,7 +71,7 @@ Feature: Value Predicate Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match $x has is-old $r;
+      match $x has is-old $r; get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -101,6 +101,7 @@ Feature: Value Predicate Resolution
       match
         $x isa person, has lucky-number $n;
         $n <op> 1667;
+      get;
       """
     Then verify answer size is: <answer-size>
     Then verify answers are sound
@@ -139,6 +140,7 @@ Feature: Value Predicate Resolution
         $x isa person, has name "Alice", has lucky-number $m;
         $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
+      get;
       """
     Then verify answer size is: <answer-size>
     Then verify answers are sound
@@ -179,6 +181,7 @@ Feature: Value Predicate Resolution
         $y isa person, has name "Bob", has lucky-number $n;
         $m <op> $n;
         $n <op> 1667;
+      get;
       """
     Then verify answer size is: <answer-size>
     Then verify answers are sound
@@ -226,6 +229,7 @@ Feature: Value Predicate Resolution
         $x has retailer $r;
         $r != $unwanted;
         $unwanted == "Ocado";
+      get;
       """
     # x     | r     |
     # Fanta | Tesco |
@@ -267,6 +271,7 @@ Feature: Value Predicate Resolution
         $x has retailer $r;
         $wanted == "Ocado";
         $r == $wanted;
+      get;
       """
     # x     | r     |
     # Fanta | Ocado |
@@ -310,6 +315,7 @@ Feature: Value Predicate Resolution
       match
         $x has retailer $rx;
         $rx contains "land";
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -353,6 +359,7 @@ Feature: Value Predicate Resolution
         $y has retailer $ry;
         $rx == $ry;
         $ry contains 'land';
+      get;
       """
     # x     | rx        | y     | ry        |
     # Fanta | Iceland   | Tango | Iceland   |
@@ -406,6 +413,7 @@ Feature: Value Predicate Resolution
         $y has retailer $ry;
         $rx != $ry;
         $ry contains 'land';
+      get;
       """
     # x     | rx        | y     | ry        |
     # Fanta | Iceland   | Tango | Poundland |
@@ -460,6 +468,7 @@ Feature: Value Predicate Resolution
       match
         $x has retailer $r;
         $r != "Ocado";
+      get;
       """
     # x     | r     |
     # Fanta | Tesco |
@@ -472,6 +481,7 @@ Feature: Value Predicate Resolution
       match
         $x has retailer $r;
         not { $r == "Ocado"; };
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -509,6 +519,7 @@ Feature: Value Predicate Resolution
       match
         $x has retailer $r;
         $r == "Ocado";
+      get;
       """
     # x     | r     |
     # Fanta | Ocado |
@@ -521,6 +532,7 @@ Feature: Value Predicate Resolution
       match
         $x has retailer $r;
         not { $r != "Ocado"; };
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -561,6 +573,7 @@ Feature: Value Predicate Resolution
           $r == $unwanted;
           $unwanted == "Ocado";
         };
+      get;
       """
     # x     | r     |
     # Fanta | Tesco |
@@ -603,6 +616,7 @@ Feature: Value Predicate Resolution
         $x has base-attribute $ax;
         $y has base-attribute $ay;
         not { $ax is $ay; };
+      get;
       """
     # x   | ax  | y   | ay  |
     # PER | BSA | SOF | NAM |
@@ -680,6 +694,7 @@ Feature: Value Predicate Resolution
       match
         $x "not expensive" isa price-range;
         ($x, item: $y) isa price-classification;
+      get;
       """
     Then verify answer size is: 2
     Then verify answers are sound
@@ -689,6 +704,7 @@ Feature: Value Predicate Resolution
       match
         $x "low price" isa price-range;
         ($x, item: $y) isa price-classification;
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -698,6 +714,7 @@ Feature: Value Predicate Resolution
       match
         $x "cheap" isa price-range;
         ($x, item: $y) isa price-classification;
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -707,6 +724,7 @@ Feature: Value Predicate Resolution
       match
         $x "expensive" isa price-range;
         ($x, item: $y) isa price-classification;
+      get;
       """
     Then verify answer size is: 1
     Then verify answers are sound
@@ -716,6 +734,7 @@ Feature: Value Predicate Resolution
       match
         $x isa price-range;
         ($x, item: $y) isa price-classification;
+      get;
       """
     # sum of all previous answers
     Then verify answer size is: 5
@@ -776,7 +795,7 @@ Feature: Value Predicate Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (predecessor:$x1, successor:$x2) isa message-succession;
+      match (predecessor:$x1, successor:$x2) isa message-succession; get;
       """
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then verify answer size is: 10

--- a/query/reasoner/variable-roles.feature
+++ b/query/reasoner/variable-roles.feature
@@ -139,14 +139,14 @@ Feature: Variable Role Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role1: $a, role2: $b) isa binary-base;
+      match (role1: $a, role2: $b) isa binary-base; get;
       """
     Then verify answer size is: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match (role1: $a, $r1: $b) isa binary-base;
+      match (role1: $a, $r1: $b) isa binary-base; get;
       """
     # $r1 in {role, role2} (2 options => double answer size)
     Then verify answer size is: 18
@@ -158,7 +158,7 @@ Feature: Variable Role Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role1: $a, $r1: $b) isa binary-base;
+      match (role1: $a, $r1: $b) isa binary-base; get;
       """
     Then verify answer size is: 18
     Then verify answers are sound
@@ -180,14 +180,14 @@ Feature: Variable Role Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role1: $a, role2: $b) isa binary-base;
+      match (role1: $a, role2: $b) isa binary-base; get;
       """
     Then verify answer size is: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match (role: $a, $r1: $b) isa binary-base;
+      match (role: $a, $r1: $b) isa binary-base; get;
       """
     # $r1 in {role, role1, role2} (3 options => triple answer size)
     Then verify answer size is: 27
@@ -199,7 +199,7 @@ Feature: Variable Role Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role: $a, $r1: $b) isa binary-base;
+      match (role: $a, $r1: $b) isa binary-base; get;
       """
     Then verify answer size is: 27
     Then verify answers are sound
@@ -221,7 +221,7 @@ Feature: Variable Role Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role: $a, $r1: $b) isa binary-base;
+      match (role: $a, $r1: $b) isa binary-base; get;
       """
     Then verify answer size is: 27
     Then verify answers are sound
@@ -247,6 +247,7 @@ Feature: Variable Role Resolution
         ($r1: $a, $r2: $b) isa binary-base;
         $r1 type relation:role;
         $r2 type binary-base:role2;
+      get;
       """
     # $r1 must be 'role' and $r2 must be 'role2'
     Then verify answer size is: 9
@@ -258,6 +259,7 @@ Feature: Variable Role Resolution
       match
         (role: $a, $r2: $b) isa binary-base;
         $r2 type binary-base:role2;
+      get;
       """
     Then verify answer size is: 9
     Then verify answers are sound
@@ -268,14 +270,14 @@ Feature: Variable Role Resolution
     Given verifier is initialised
     Given reasoning query
       """
-      match (role1: $a, role2: $b) isa binary-base;
+      match (role1: $a, role2: $b) isa binary-base; get;
       """
     Then verify answer size is: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
-      match ($r1: $a, $r2: $b) isa binary-base;
+      match ($r1: $a, $r2: $b) isa binary-base; get;
       """
     # r1    | r2    |
     # role  | role  |
@@ -342,18 +344,19 @@ Feature: Variable Role Resolution
       match
         (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
         $a1 has name 'a';
+      get;
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3) isa binary-base, as role1 and $a1 each have only 1 value
     Then verify answer size is: 63
     Given reasoning query
       """
-      match (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
+      match (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base; get;
       """
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then verify answer size is: 189
     Given reasoning query
       """
-      match ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
+      match ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base; get;
       """
     # r1    | r2    | r3    |
     # role  | role  | role  | 1 pattern
@@ -378,18 +381,19 @@ Feature: Variable Role Resolution
       match
         (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
         $a1 has name 'a';
+      get;
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary-base
     Then verify answer size is: 918
     Given reasoning query
       """
-      match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
+      match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base; get;
       """
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
     Then verify answer size is: 2754
     Given reasoning query
       """
-      match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
+      match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base; get;
       """
     # {r1,r2,r3,r4}
     # 4 occurrences of 'role' | 1 pattern
@@ -413,18 +417,19 @@ Feature: Variable Role Resolution
       match
         (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
         $a1 has name 'a';
+      get;
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary
     Then verify answer size is: 272
     Given reasoning query
       """
-      match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
+      match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary; get;
       """
     # Now the bound role 'role1' is in {a, b}, doubling the answer size
     Then verify answer size is: 544
     Given reasoning query
       """
-      match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
+      match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary; get;
       """
     # {r1,r2,r3,r4} | 209 patterns (see 'quaternary-base' scenario for details)
     # For each pattern, we have one possible match per quaternary relation


### PR DESCRIPTION
## What is the goal of this PR?

We implement a new set of behaviour tests, `fetch.feature`, which outline the expected behaviours of the new 'Fetch' query type.
We also refactor existing steps to use the new "TypeQL Get" query terminology, replacing "TypeQL Match" query terminology.

## What are the changes implemented in this PR?

* Implement 'fetch.feature', which outlines expected behaviours of Fetch queries
* Refactor existing steps to use the new "TypeQL Get" query terminology, replacing "TypeQL Match" query terminology.
* Add missing 'get;' clauses to Get queries that were missing them, as they are now mandatory
* Scenarios to do with 'get-aggregate' returning an empty answer now no longer use the "not a value" terminology, and reflect the return of empty optionals instead.