### PR TITLE
Fix: ref attribute must be owned as @key

### DIFF
--- a/typeql/language/match.feature
+++ b/typeql/language/match.feature
@@ -1760,7 +1760,7 @@ Feature: TypeQL Match Query
     Given typeql define
       """
       define
-      unit sub attribute, value string, owns unit, owns ref;
+      unit sub attribute, value string, owns unit, owns ref @key;
       """
     Given transaction commits
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix an issue where a newly defined type owned `ref` as non-key, which did not allow the behaviour tests to correctly identify answer concepts.