### PR TITLE
Rename Client to Driver throughout

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -16,8 +16,8 @@ Please replace every line in curly brackets { like this } with an appropriate an
 ## Environment
 
 1. OS (where TypeDB server runs): { e.g. Mac OS 10, Windows 10, Ubuntu 16.4, etc. }
-2. TypeDB version (and platform): { e.g. TypeDB 2.0.0, or TypeDB Cluster 2.0.0 on Google Cloud }
-3. TypeDB client: { e.g. client-java, client-python, client-nodejs, or console }
+2. TypeDB version (and platform): { e.g. TypeDB 2.0.0, or TypeDB Enterprise 2.0.0 on Google Cloud }
+3. TypeDB driver: { e.g. driver-java, driver-python, driver-nodejs, driver-rust, or console }
 4. Other environment details:
 
 ## Reproducible Steps

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -137,7 +137,7 @@ Feature: Connection Database
     Then connection has database: alice
 
 
-  # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see client-java#225)
+  # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see driver-java#225)
   @ignore
   Scenario: delete a database causes open sessions to fail
     When connection create database: typedb
@@ -147,7 +147,7 @@ Feature: Connection Database
     Then session open transaction of type; throws exception: write
 
 
-  # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see client-java#225)
+  # TODO: currently throws in @After; re-enable when we are able to check if sessions are alive (see driver-java#225)
   @ignore
   Scenario: delete a database causes open transactions to fail
     When connection create database: typedb

--- a/connection/user.feature
+++ b/connection/user.feature
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-# TODO: remove ignores for client-python and client-node once bootup can be configured through BDD
+# TODO: remove ignores for driver-python and driver-node once bootup can be configured through BDD
 Feature: Connection Users
 
   Scenario: users can be created and deleted
@@ -44,7 +44,7 @@ Feature: Connection Users
     Given connection opens with authentication: user, password
     Then get connected user
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must comply with the minimum length
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -55,7 +55,7 @@ Feature: Connection Users
     Then users create: user2, passw
     Then users create: user3, pass; throws exception
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must comply with the minimum number of lowercase characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -66,7 +66,7 @@ Feature: Connection Users
     Then users create: user2, paSSWORD
     Then users create: user3, PASSWORD; throws exception
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must comply with the minimum number of uppercase characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -77,7 +77,7 @@ Feature: Connection Users
     Then users create: user2, PAssword
     Then users create: user3, password; throws exception
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must comply with the minimum number of numeric characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -88,7 +88,7 @@ Feature: Connection Users
     Then users create: user2, PASSWORD78
     Then users create: user3, PASSWORD7; throws exception
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must comply with the minimum number of special characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -99,7 +99,7 @@ Feature: Connection Users
     Then users create: user2, PASSWORD&(
     Then users create: user3, PASSWORD); throws exception
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must comply with the minimum number of different characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -117,7 +117,7 @@ Feature: Connection Users
     Then connection closes
     Given connection opens with authentication: user, even-newer-password
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords must be unique for a certain history size
     Given typedb has configuration
       |server.authentication.password-policy.unique-history-size|2|
@@ -140,7 +140,7 @@ Feature: Connection Users
     Given connection opens with authentication: user, newest-password
     And user password update: newest-password, password
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user can check their own password expiration seconds
     Given typedb has configuration
       |server.authentication.password-policy.expiration.enable|true|
@@ -153,7 +153,7 @@ Feature: Connection Users
     Given connection opens with authentication: user, password
     Then user expiry-seconds
 
-  @ignore-typedb-client-python @ignore-typedb-client-nodejs @ignore-typedb-client-rust
+  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
   Scenario: user passwords expire
     Given typedb has configuration
       |server.authentication.password-policy.expiration.enable|true|

--- a/typeql/explanation/language.feature
+++ b/typeql/explanation/language.feature
@@ -25,7 +25,7 @@ Feature: TypeQL Reasoning Explanation
     Given connection open schema session for database: test_explanation
     Given transaction is initialised
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: atomic query has lookup explanation
 
   Verify the code path for atomic queries produces correct explanation and pattern.
@@ -59,7 +59,7 @@ Feature: TypeQL Reasoning Explanation
       |   | children | vars | identifiers | explanation | pattern                                    |
       | 0 | -        | p    | AL          | lookup      | { $p isa person; $p iid <answer.p.iid>; }; |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: relation has lookup explanation
     Given typeql define
       """
@@ -111,7 +111,7 @@ Feature: TypeQL Reasoning Explanation
       |   | children | vars    | identifiers  | explanation | pattern                                                                                                                                                        |
       | 0 | -        | k, l, n | KC, LDN, KCn | lookup      | { $k isa area; $k has name $n; (superior: $l, subordinate: $k) isa location-hierarchy; $k iid <answer.k.iid>; $n iid <answer.n.iid>; $l iid <answer.l.iid>; }; |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: non-atomic query has lookup explanation with the full pattern
 
   Verify the code path for non-atomic queries produces correct explanation and pattern.
@@ -170,7 +170,7 @@ Feature: TypeQL Reasoning Explanation
       |   | children | vars       | identifiers      | explanation | pattern                                                                                                                                                                                                                                       |
       | 0 | -        | k, l, u, n | KC, LDN, UK, KCn | lookup      | { $k isa area; $k has name $n; (superior: $l, subordinate: $k) isa location-hierarchy; (superior: $u, subordinate: $l) isa location-hierarchy; $u iid <answer.u.iid>; $l iid <answer.l.iid>; $k iid <answer.k.iid>; $n iid <answer.n.iid>; }; |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a query containing a negation has a negation explanation
 
   A negation explanation shows the resolution that occurred. It contains the pattern for the lookup that was performed,
@@ -219,7 +219,7 @@ Feature: TypeQL Reasoning Explanation
       | 0 | 1        | com, n | ACO, N      | negation    | { $com isa company; $com has name $n; $com iid <answer.com.iid>; $n iid <answer.n.iid>; not { { $n == "the-company"; }; }; }; |
       | 1 | -        | com, n | ACO, N      | lookup      | { $com isa company; $com has name $n; $com iid <answer.com.iid>; $n iid <answer.n.iid>; };                                    |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a query containing a disjunction has a disjunctive explanation
 
   Ids in the answer's pattern should sit outside the disjunction, this makes the disjunction valid as it provides outer scope variables for the disjunction to bind to.
@@ -267,7 +267,7 @@ Feature: TypeQL Reasoning Explanation
       | 0 | 1        | com     | ACO         | disjunction | { $com iid <answer.com.iid>; { $com isa company; $com has name $n1; $n1 == "the-company";} or {$com isa company; $com has name $n2; $n2 == "another-company";}; }; |
       | 1 | -        | com, n2 | ACO, N2     | lookup      | { $com isa company; $com has name $n2; $n2 == "another-company"; $com iid <answer.com.iid>; $n2 iid <answer.n2.iid>; };                                            |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a query containing a nested disjunction has a single disjunctive explanation due to DNF
 
   Due to the use of Disjunctive Normal Form, the answer's pattern should contain only one disjunction with ids outside as the outer scope.

--- a/typeql/explanation/reasoner.feature
+++ b/typeql/explanation/reasoner.feature
@@ -27,7 +27,7 @@ Feature: TypeQL Reasoning Explanation
     Given connection open schema session for database: test_explanation
     Given transaction is initialised
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a rule explanation is given when a rule is applied
     Given typeql define
       """
@@ -76,7 +76,7 @@ Feature: TypeQL Reasoning Explanation
       | 0 | 1        | co, n | CO, CON     | company-has-name | { $co iid <answer.co.iid>; $co has name $n; $n iid <answer.n.iid>; }; |
       | 1 | -        | c     | CO          | lookup           | { $c isa company; $c iid <answer.c.iid>; };                           |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: nested rule explanations are given when multiple rules are applied
     Given typeql define
       """
@@ -141,7 +141,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | 2        | c2, name | CO, CON     | company-has-name  | { $c2 isa company; $c2 has name $name; $name == "the-company"; $c2 iid <answer.c2.iid>; $name iid <answer.name.iid>; }; |
       | 2 | -        | c1       | CO          | lookup            | { $c1 isa company; $c1 iid <answer.c1.iid>; };                                                                         |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a join explanation can be given directly and inside a rule explanation
     Given typeql define
       """
@@ -219,7 +219,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | -        | k, n    | KC, KCN      | lookup      | { $k isa area; $k has name $n; $n iid <answer.n.iid>; $k iid <answer.k.iid>; };                                                                                |
       | 2 | -        | k, l    | KC, LDN      | lookup      | { (superior: $l, subordinate: $k) isa location-hierarchy; $k isa area; $k iid <answer.k.iid>; $l iid <answer.l.iid>; };                                        |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: an answer with a more specific type can be retrieved from the cache with correct explanations
     Given typeql define
       """
@@ -310,7 +310,7 @@ Feature: TypeQL Reasoning Explanation
       | 3 | -        | p1, na        | ALI, ALIN            | lookup               | { $p1 isa woman; $p1 has name $na; $na == "Alice"; $p1 iid <answer.p1.iid>; $na iid <answer.na.iid>; };                                                                                           |
       | 4 | -        | man           | BOB                  | lookup               | { $man isa man; $man iid <answer.man.iid>; };                                                                                                                                                    |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a query with a disjunction and negated inference has disjunctive and negation explanation but no rule explanation
 
   A rule explanation is not be given since the rule was only used to infer facts that were later negated
@@ -375,7 +375,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | 2        | com, n2 | ACO, N2     | negation    | { $com isa company; $com has name $n2; $n2 == "another-company"; $com iid <answer.com.iid>; $n2 iid <answer.n2.iid>; not { { $com has is-liable $liability; }; }; };                                                                                          |
       | 2 | -        | com, n2 | ACO, N2     | lookup      | { $com isa company; $com has name $n2; $n2 == "another-company"; $com iid <answer.com.iid>; $n2 iid <answer.n2.iid>; };                                                                                                                                       |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a rule containing a negation gives a rule explanation with a negation explanation inside
     Given typeql define
       """
@@ -438,7 +438,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | 2        | c2       | ACO         | negation          | { $c2 isa company; $c2 iid <answer.c2.iid>; not { { $c2 has name $n2; $n2 == "the-company"; }; }; };                |
       | 2 | -        | c2       | ACO         | lookup            | { $c2 isa company; $c2 iid <answer.c2.iid>; };                                                                     |
 
-  @ignore-typedb-client-java
+  @ignore-typedb-driver-java
   Scenario: a query containing multiple negations with inferred conjunctions inside has just one negation explanation
 
   A rule explanation is not be given since the rule was only used to infer facts that were later negated

--- a/typeql/language/define.feature
+++ b/typeql/language/define.feature
@@ -1261,7 +1261,7 @@ Feature: TypeQL Define Query
       | label:super-name | label:location-name |
 
   # TODO: Reenable this scenario after closing https://github.com/vaticle/typeql/issues/281
-  @ignore-typedb-client-rust
+  @ignore-typedb-driver-rust
   Scenario: repeating the term 'abstract' when defining a type causes an error to be thrown
     Given typeql define; throws exception
       """
@@ -2436,10 +2436,10 @@ Feature: TypeQL Define Query
   # TRANSACTIONALITY #
   ####################
 
-  # TODO: re-enable when it passes reliably in clients (see client-java#233)
-  @ignore-typedb-client-java
-  @ignore-typedb-client-nodejs
-  @ignore-typedb-client-python
+  # TODO: re-enable when it passes reliably in drivers (see driver-java#233)
+  @ignore-typedb-driver-java
+  @ignore-typedb-driver-nodejs
+  @ignore-typedb-driver-python
   Scenario: uncommitted transaction writes are not persisted
     When typeql define
       """


### PR DESCRIPTION
## What is the goal of this PR?

We replace the term 'client' with 'driver', to reflect the new consistent terminology used through Vaticle.

## What are the changes implemented in this PR?

* Update PR template and ignores to use 'driver' instead of 'client'.