### PR TITLE
Disallow explicit use of role type aliases

### DIFF
--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -597,6 +597,15 @@ Feature: TypeQL Define Query
       | label:flight-attendant-employment |
 
 
+  Scenario: inherited role types cannot be played via role type aliases
+    Given typeql define; throws exception
+      """
+      define
+      part-time-employment sub employment;
+      person plays part-time-employment:employee;
+      """
+
+
   Scenario: a newly defined relation subtype inherits attribute ownerships from its parent type
     Given typeql define
       """

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -2201,6 +2201,28 @@ Parker";
       $x has $a; $a isa $t;
       """
 
+  Scenario: variable types in inserts cannot use aliased role types
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      part-time-employment sub employment;
+      """
+    Given transaction commits
+    Given connection close all sessions
+
+    Given connection open data session for database: typedb
+    When session opens transaction of type: write
+    Then typeql insert; throws exception
+      """
+      match
+      $t type part-time-employment:employee;
+      insert
+      ($t: $x) isa part-time-employment;
+      $x isa person;
+      """
 
   #####################################
   # MATERIALISATION OF INFERRED FACTS #

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -485,6 +485,21 @@ Feature: TypeQL Match Query
       | label:person |
 
 
+  Scenario: inherited role types cannot be be matched via role type alias
+    Given typeql define
+      """
+      define
+      close-friendship sub friendship;
+      """
+    Given transaction commits
+
+    Given session opens transaction of type: read
+    When typeql match; throws exception
+      """
+      match $x plays close-friendship:friend;
+      """
+
+
   Scenario: 'plays' does not match types that only play a super-role of the specified role
     Given typeql define
       """

--- a/query/language/rule-validation.feature
+++ b/query/language/rule-validation.feature
@@ -443,6 +443,21 @@ Feature: TypeQL Rule Validation
       """
 
 
+  Scenario: when defining a rule using an aliased role type, an error is thrown
+    Then typeql define; throws exception
+      """
+      define
+      part-time-employment sub employment;
+      rule people-are-part-time-employees:
+      when {
+        $x isa person;
+        $t type part-time-employment:employee;
+      } then {
+        ($t: $x) isa part-time-employment;
+      };
+      """
+
+
   Scenario: when defining a rule to generate new entities from existing ones, an error is thrown
     Given typeql define
       """

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -817,7 +817,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given typeql undefine
+    Given typeql undefine; throws exception
     """
     undefine
     person plays part-time-employment:employee;

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -808,6 +808,22 @@ Feature: TypeQL Undefine Query
       """
 
 
+  Scenario: undefining played inherited role types using alias role types throws
+    Given typeql define
+    """
+    define
+    part-time-employment sub employment;
+    """
+    Given transaction commits
+
+    Given session opens transaction of type: write
+    Given typeql undefine
+    """
+    undefine
+    person plays part-time-employment:employee;
+    """
+
+
   Scenario: removing a playable role throws an error if it is played by existing instances
     Given connection close all sessions
     Given connection open data session for database: typedb

--- a/query/reasoner/recursion.feature
+++ b/query/reasoner/recursion.feature
@@ -990,24 +990,25 @@ Feature: Recursion Resolution
 
       vertex sub entity,
         owns index @key,
-        plays reachable:coordinate;
+        plays link:coordinate,
+        plays reachable:reachable-coordinate;
 
       link sub relation, relates coordinate;
-      reachable sub link;
+      reachable sub link, relates reachable-coordinate as coordinate;
 
       index sub attribute, value string;
 
       rule a-linked-point-is-reachable: when {
         ($x, $y) isa link;
       } then {
-        (coordinate: $x, coordinate: $y) isa reachable;
+        (reachable-coordinate: $x, reachable-coordinate: $y) isa reachable;
       };
 
       rule a-point-reachable-from-a-linked-point-is-reachable: when {
         ($x, $z) isa link;
         ($z, $y) isa reachable;
       } then {
-        (coordinate: $x, coordinate: $y) isa reachable;
+        (reachable-coordinate: $x, reachable-coordinate: $y) isa reachable;
       };
       """
     Given reasoning data


### PR DESCRIPTION
## What is the goal of this PR?

We concretely specify the behaviours of inherited role types and role type aliasing, as outlined in the closing comment of https://github.com/vaticle/typeql/issues/274.

## What are the changes implemented in this PR?

* Add scenarios rejecting the use of explicit role type aliasing (`relation-type:inherited-role`)