### PR TITLE
User management tests only run on server when configuring passwords

### DIFF
--- a/connection/user.feature
+++ b/connection/user.feature
@@ -45,7 +45,7 @@ Feature: Connection Users
     Given connection opens with authentication: user, password
     Then get connected user
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must comply with the minimum length
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -56,7 +56,7 @@ Feature: Connection Users
     Then users create: user2, passw
     Then users create: user3, pass; throws exception
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must comply with the minimum number of lowercase characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -67,7 +67,7 @@ Feature: Connection Users
     Then users create: user2, paSSWORD
     Then users create: user3, PASSWORD; throws exception
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must comply with the minimum number of uppercase characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -78,7 +78,7 @@ Feature: Connection Users
     Then users create: user2, PAssword
     Then users create: user3, password; throws exception
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must comply with the minimum number of numeric characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -89,7 +89,7 @@ Feature: Connection Users
     Then users create: user2, PASSWORD78
     Then users create: user3, PASSWORD7; throws exception
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must comply with the minimum number of special characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -100,7 +100,7 @@ Feature: Connection Users
     Then users create: user2, PASSWORD&(
     Then users create: user3, PASSWORD); throws exception
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must comply with the minimum number of different characters
     Given typedb has configuration
       |server.authentication.password-policy.complexity.enable|true|
@@ -118,7 +118,7 @@ Feature: Connection Users
     Then connection closes
     Given connection opens with authentication: user, even-newer-password
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords must be unique for a certain history size
     Given typedb has configuration
       |server.authentication.password-policy.unique-history-size|2|
@@ -141,7 +141,7 @@ Feature: Connection Users
     Given connection opens with authentication: user, newest-password
     And user password update: newest-password, password
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user can check their own password expiration seconds
     Given typedb has configuration
       |server.authentication.password-policy.expiration.enable|true|
@@ -154,7 +154,7 @@ Feature: Connection Users
     Given connection opens with authentication: user, password
     Then user expiry-seconds
 
-  @ignore-typedb-driver-python @ignore-typedb-driver-nodejs @ignore-typedb-driver-rust
+  @ignore-typedb-driver
   Scenario: user passwords expire
     Given typedb has configuration
       |server.authentication.password-policy.expiration.enable|true|

--- a/query/explanation/language.feature
+++ b/query/explanation/language.feature
@@ -25,7 +25,7 @@ Feature: TypeQL Reasoning Explanation
     Given connection open schema session for database: test_explanation
     Given transaction is initialised
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: atomic query has lookup explanation
 
   Verify the code path for atomic queries produces correct explanation and pattern.
@@ -59,7 +59,7 @@ Feature: TypeQL Reasoning Explanation
       |   | children | vars | identifiers | explanation | pattern                                    |
       | 0 | -        | p    | AL          | lookup      | { $p isa person; $p iid <answer.p.iid>; }; |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: relation has lookup explanation
     Given typeql define
       """
@@ -112,7 +112,7 @@ Feature: TypeQL Reasoning Explanation
       |   | children | vars    | identifiers  | explanation | pattern                                                                                                                                                        |
       | 0 | -        | k, l, n | KC, LDN, KCn | lookup      | { $k isa area; $k has name $n; (superior: $l, subordinate: $k) isa location-hierarchy; $k iid <answer.k.iid>; $n iid <answer.n.iid>; $l iid <answer.l.iid>; }; |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: non-atomic query has lookup explanation with the full pattern
 
   Verify the code path for non-atomic queries produces correct explanation and pattern.
@@ -172,7 +172,7 @@ Feature: TypeQL Reasoning Explanation
       |   | children | vars       | identifiers      | explanation | pattern                                                                                                                                                                                                                                       |
       | 0 | -        | k, l, u, n | KC, LDN, UK, KCn | lookup      | { $k isa area; $k has name $n; (superior: $l, subordinate: $k) isa location-hierarchy; (superior: $u, subordinate: $l) isa location-hierarchy; $u iid <answer.u.iid>; $l iid <answer.l.iid>; $k iid <answer.k.iid>; $n iid <answer.n.iid>; }; |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a query containing a negation has a negation explanation
 
   A negation explanation shows the resolution that occurred. It contains the pattern for the lookup that was performed,
@@ -221,7 +221,7 @@ Feature: TypeQL Reasoning Explanation
       | 0 | 1        | com, n | ACO, N      | negation    | { $com isa company; $com has name $n; $com iid <answer.com.iid>; $n iid <answer.n.iid>; not { { $n == "the-company"; }; }; }; |
       | 1 | -        | com, n | ACO, N      | lookup      | { $com isa company; $com has name $n; $com iid <answer.com.iid>; $n iid <answer.n.iid>; };                                    |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a query containing a disjunction has a disjunctive explanation
 
   Ids in the answer's pattern should sit outside the disjunction, this makes the disjunction valid as it provides outer scope variables for the disjunction to bind to.
@@ -270,7 +270,7 @@ Feature: TypeQL Reasoning Explanation
       | 0 | 1        | com     | ACO         | disjunction | { $com iid <answer.com.iid>; { $com isa company; $com has name $n1; $n1 == "the-company";} or {$com isa company; $com has name $n2; $n2 == "another-company";}; }; |
       | 1 | -        | com, n2 | ACO, N2     | lookup      | { $com isa company; $com has name $n2; $n2 == "another-company"; $com iid <answer.com.iid>; $n2 iid <answer.n2.iid>; };                                            |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a query containing a nested disjunction has a single disjunctive explanation due to DNF
 
   Due to the use of Disjunctive Normal Form, the answer's pattern should contain only one disjunction with ids outside as the outer scope.

--- a/query/explanation/reasoner.feature
+++ b/query/explanation/reasoner.feature
@@ -27,7 +27,7 @@ Feature: TypeQL Reasoning Explanation
     Given connection open schema session for database: test_explanation
     Given transaction is initialised
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a rule explanation is given when a rule is applied
     Given typeql define
       """
@@ -76,7 +76,7 @@ Feature: TypeQL Reasoning Explanation
       | 0 | 1        | co, n | CO, CON     | company-has-name | { $co iid <answer.co.iid>; $co has name $n; $n iid <answer.n.iid>; }; |
       | 1 | -        | c     | CO          | lookup           | { $c isa company; $c iid <answer.c.iid>; };                           |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: nested rule explanations are given when multiple rules are applied
     Given typeql define
       """
@@ -141,7 +141,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | 2        | c2, name | CO, CON     | company-has-name  | { $c2 isa company; $c2 has name $name; $name == "the-company"; $c2 iid <answer.c2.iid>; $name iid <answer.name.iid>; }; |
       | 2 | -        | c1       | CO          | lookup            | { $c1 isa company; $c1 iid <answer.c1.iid>; };                                                                         |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a join explanation can be given directly and inside a rule explanation
     Given typeql define
       """
@@ -220,7 +220,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | -        | k, n    | KC, KCN      | lookup      | { $k isa area; $k has name $n; $n iid <answer.n.iid>; $k iid <answer.k.iid>; };                                                                                |
       | 2 | -        | k, l    | KC, LDN      | lookup      | { (superior: $l, subordinate: $k) isa location-hierarchy; $k isa area; $k iid <answer.k.iid>; $l iid <answer.l.iid>; };                                        |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: an answer with a more specific type can be retrieved from the cache with correct explanations
     Given typeql define
       """
@@ -311,7 +311,7 @@ Feature: TypeQL Reasoning Explanation
       | 3 | -        | p1, na        | ALI, ALIN            | lookup               | { $p1 isa woman; $p1 has name $na; $na == "Alice"; $p1 iid <answer.p1.iid>; $na iid <answer.na.iid>; };                                                                                           |
       | 4 | -        | man           | BOB                  | lookup               | { $man isa man; $man iid <answer.man.iid>; };                                                                                                                                                    |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a query with a disjunction and negated inference has disjunctive and negation explanation but no rule explanation
 
   A rule explanation is not be given since the rule was only used to infer facts that were later negated
@@ -377,7 +377,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | 2        | com, n2 | ACO, N2     | negation    | { $com isa company; $com has name $n2; $n2 == "another-company"; $com iid <answer.com.iid>; $n2 iid <answer.n2.iid>; not { { $com has is-liable $liability; }; }; };                                                                                          |
       | 2 | -        | com, n2 | ACO, N2     | lookup      | { $com isa company; $com has name $n2; $n2 == "another-company"; $com iid <answer.com.iid>; $n2 iid <answer.n2.iid>; };                                                                                                                                       |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a rule containing a negation gives a rule explanation with a negation explanation inside
     Given typeql define
       """
@@ -440,7 +440,7 @@ Feature: TypeQL Reasoning Explanation
       | 1 | 2        | c2       | ACO         | negation          | { $c2 isa company; $c2 iid <answer.c2.iid>; not { { $c2 has name $n2; $n2 == "the-company"; }; }; };                |
       | 2 | -        | c2       | ACO         | lookup            | { $c2 isa company; $c2 iid <answer.c2.iid>; };                                                                     |
 
-  @ignore-typedb-driver-java
+  @ignore-typedb-driver
   Scenario: a query containing multiple negations with inferred conjunctions inside has just one negation explanation
 
   A rule explanation is not be given since the rule was only used to infer facts that were later negated

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -2449,10 +2449,6 @@ Feature: TypeQL Define Query
   # TRANSACTIONALITY #
   ####################
 
-  # TODO: re-enable when it passes reliably in drivers (see driver-java#233)
-  @ignore-typedb-driver-java
-  @ignore-typedb-driver-nodejs
-  @ignore-typedb-driver-python
   Scenario: uncommitted transaction writes are not persisted
     When typeql define
       """


### PR DESCRIPTION
## Release notes: usage and product changes

We simplify the ignore tags on user management scenarios, excluding all tests beyond the simples ones  from being run in the drivers. The intent is now to only test anything requiring server configuration on the server side.

## Implementation

- switch to `ignore-typedb-driver` to all user tests that require configuring the server on bootup.
- clean up existing ignore tags using generalised `ignore-typedb-driver` to cover future drivers as well