### PR TITLE
Test fetch with reasoning and limit edge cases

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -26,10 +26,7 @@ assignees: ''
 2. Execute
 
 
-3. Test/Query
-
-
-4. Unexpected result
+3. Unexpected result
 
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## Release notes: usage and product changes
+## Usage and product changes
 
 
 ## Implementation


### PR DESCRIPTION
## Usage and product changes

We add 'Fetch' query scenarios to validate that attribute fetching can retrieve inferred attribute ownerships, and also ensure that a 'limit' on the outer 'match' query does not affect the inner fetch operations.

## Implementation

- Add scenario for testing that attribute fetch triggers reasoning
- Add scenario for testing that subquery fetch triggers reasoning
- Add scenario to test that limits on the outer 'match' clause do not affect the inner fetch operations
