### PR TITLE
Test fetch subquery with null

### DIFF
--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -474,6 +474,28 @@ Feature: TypeQL Fetch Query
       """
 
 
+  Scenario: a fetch subquery can be a match-aggregate query with zero answers
+    When get answers of typeql fetch
+      """
+      match
+      $p isa person, has person-name "Bob";
+      fetch
+      ages-sum: {
+        match
+        $p has age $a;
+        get $a;
+        sum $a;
+      };
+      limit 1;
+      """
+    Then fetch answers are
+      """
+      [{
+        "ages-sum": null
+      }]
+      """
+
+
   Scenario: fetch subqueries can be nested and use bindings from any parent
     Given session transaction closes
     Given session opens transaction of type: write


### PR DESCRIPTION
## Usage and product changes

We add a scenario to validate the a match-aggregate sub query in a 'fetch' clause can return an empty answer, and this answer is rendered as 'null' in JSON format.

## Implementation

Add a test that returns a Null answer for match-aggregates that don't have an answer.