### PR TITLE
Sync dependencies in CI

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -23,7 +23,7 @@ build:
   quality:
     filter:
       owner: vaticle
-      branch: master
+      branch: [master, development]
     dependency-analysis:
       image: vaticle-ubuntu-22.04
       command: |
@@ -35,4 +35,13 @@ build:
         bazel build //... --test_output=errors
         bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+    sync-dependencies:
+      image: vaticle-ubuntu-22.04
+      filter:
+        owner: vaticle
+        branch: [master, development]
+      dependencies: [build]
+      command: |
+          export SYNC_DEPENDENCIES_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
       

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,14 +24,6 @@ workspace(name = "vaticle_typedb_behaviour")
 load("//dependencies/vaticle:repositories.bzl", "vaticle_dependencies")
 vaticle_dependencies()
 
-# Load //tool/common
-load("@vaticle_dependencies//tool/common:deps.bzl", "vaticle_dependencies_ci_pip", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
-vaticle_dependencies_ci_pip()
-
-# Load //tool/checkstyle
-load("@vaticle_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")
-checkstyle_deps()
-
 # Load //builder/bazel for RBE
 load("@vaticle_dependencies//builder/bazel:deps.bzl", "bazel_toolchain")
 bazel_toolchain()
@@ -52,6 +44,14 @@ load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 kotlin_repositories()
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
+
+# Load //tool/common
+load("@vaticle_dependencies//tool/common:deps.bzl", "vaticle_dependencies_ci_pip", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
+vaticle_dependencies_ci_pip()
+
+# Load //tool/checkstyle
+load("@vaticle_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")
+checkstyle_deps()
 
 ############################
 # Load @maven dependencies #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,6 +24,10 @@ workspace(name = "vaticle_typedb_behaviour")
 load("//dependencies/vaticle:repositories.bzl", "vaticle_dependencies")
 vaticle_dependencies()
 
+# Load //tool/common
+load("@vaticle_dependencies//tool/common:deps.bzl", "vaticle_dependencies_ci_pip", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
+vaticle_dependencies_ci_pip()
+
 # Load //tool/checkstyle
 load("@vaticle_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")
 checkstyle_deps()
@@ -48,8 +52,6 @@ load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 kotlin_repositories()
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
-
-load("@vaticle_dependencies//tool/common:deps.bzl", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
 
 ############################
 # Load @maven dependencies #


### PR DESCRIPTION
## Usage and product changes

We add a sync-dependencies job to be run in CI after successful snapshot and release deployments. The job sends a request to vaticle-bot to update all downstream dependencies.

Note: this PR does _not_ update the `dependencies` repo dependency. It will be updated automatically by the bot during its first pass.