### PR TITLE
Test empty relation chain is deleted on commit

### DIFF
--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -144,6 +144,33 @@ Feature: Concept Relation
     Then relation $m is null: true
     Then relation(marriage) get instances is empty
 
+  Scenario: Relation chain with no other role players gets deleted on commit
+    Then for each session, transaction closes
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given relation(marriage) set relates role: dependent-marriage
+    Given relation(marriage) set plays role: marriage:dependent-marriage
+    Given transaction commits
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+
+    When $m = relation(marriage) create new instance with key(license): m
+    When $n = relation(marriage) create new instance with key(license): n
+    When $o = relation(marriage) create new instance with key(license): o
+    When $p = relation(marriage) create new instance with key(license): p
+    When $q = relation(marriage) create new instance with key(license): q
+    When $r = relation(marriage) create new instance with key(license): r
+    When relation $m add player for role(dependent-marriage): $n
+    When relation $n add player for role(dependent-marriage): $o
+    When relation $o add player for role(dependent-marriage): $p
+    When relation $p add player for role(dependent-marriage): $q
+    When relation $q add player for role(dependent-marriage): $r
+    When transaction commits
+    When session opens transaction of type: read
+    Then relation(marriage) get instances is empty
+
   Scenario: Relation with role players can be deleted
     When $m = relation(marriage) create new instance with key(license): m
     When $a = entity(person) create new instance with key(username): alice


### PR DESCRIPTION
## Usage and product changes

We validate that a chain of relations, with only other relations in the chain which terminate at an empty relation, are correctly cleaned up on commit.

Diagrammatically:
```
r1 -> r2 -> r3 -> r4
```
TypeDB should delete them in reverse order on commit, since it automatically cleans up relations with no role players.

## Implementation

* Add a `relation` scenario that creates a relation chain terminating in an empty relation, and validates that they all get cleaned up on commit.
