### PR TITLE
Add scenario ensuring buffered iids in overrides are translated

### DIFF
--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -522,6 +522,20 @@ Feature: Concept Relation Type and Role Type
     When relation(parentship) set relates role: parent
     Then relation(parentship) set relates role: father as parent; throws exception
 
+  Scenario: Relation types can update existing roles override a newly defined role it inherits
+    When put relation type: parentship
+    When relation(parentship) set relates role: other-role
+    When put relation type: fathership
+    When relation(fathership) set supertype: parentship
+    When relation(fathership) set relates role: father
+    When transaction commits
+    When session opens transaction of type: write
+    When relation(parentship) set relates role: parent
+    When relation(fathership) set relates role: father as parent
+    When transaction commits
+    When session opens transaction of type: read
+    Then relation(fathership) get overridden role(father) get label: parent
+
   Scenario: Relation types can have keys
     When put attribute type: license, with value type: string
     When put relation type: marriage


### PR DESCRIPTION
## Usage and product changes
Adds test for a bug which creates an invalid override when a committed role-type is overridden with a newly defined role-type.

## Implementation
Adds test for a bug which creates an invalid override when a committed role-type is overridden with a newly defined role-type. The bug was caused by Persisted TypeEdges assuming any overridden IID would also be persisted.

