### PR TITLE
Add scenarios for insertion of relations with implicit role types

### DIFF
--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -922,7 +922,7 @@ get;
       | key:ref:0 | key:ref:1 |
 
 
-  Scenario: a role player can be inserted without explicitly specifying a role
+  Scenario: a roleplayer can be inserted without explicitly specifying a role
     Given typeql insert
       """
       insert
@@ -931,7 +931,7 @@ get;
       """
     Then transaction commits
 
-  Scenario: a role can only be implicit if there is no ambiguity
+  Scenario: when inserting a roleplayer that can play more than one role, and error is thrown
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
@@ -952,7 +952,7 @@ get;
       $p isa person, has ref 1;
       """
 
-  Scenario: an inherited role can be implicit
+  Scenario: a roleplayer can be inserted without explicitly specifying a role when the role is inherited
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
@@ -960,29 +960,6 @@ get;
       """
       define
       part-time-employment sub employment;
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql insert
-      """
-      insert
-      $r ($p) isa part-time-employment, has ref 0;
-      $p isa person, has ref 1;
-      """
-    Then transaction commits
-
-  Scenario: an inherited role can be implicit unambiguously when the player is declared to play both the overridden role and its supertype
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-      """
-      define
-      part-time-employment sub employment, relates part-time-employee as employee;
-      person plays part-time-employment:part-time-employee;
       """
     Given transaction commits
 

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -931,27 +931,6 @@ get;
       """
     Then transaction commits
 
-  Scenario: when inserting a roleplayer that can play more than one role, and error is thrown
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql define
-      """
-      define
-      person plays employment:employer;
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql insert; throws exception
-      """
-      insert
-      $r ($p) isa employment, has ref 0;
-      $p isa person, has ref 1;
-      """
-
   Scenario: a roleplayer can be inserted without explicitly specifying a role when the role is inherited
     Given connection close all sessions
     Given connection open schema session for database: typedb
@@ -973,6 +952,27 @@ get;
       $p isa person, has ref 1;
       """
     Then transaction commits
+
+  Scenario: when inserting a roleplayer that can play more than one role, an error is thrown
+    Given connection close all sessions
+    Given connection open schema session for database: typedb
+    Given session opens transaction of type: write
+    Given typeql define
+      """
+      define
+      person plays employment:employer;
+      """
+    Given transaction commits
+
+    Given connection close all sessions
+    Given connection open data session for database: typedb
+    Given session opens transaction of type: write
+    Then typeql insert; throws exception
+      """
+      insert
+      $r ($p) isa employment, has ref 0;
+      $p isa person, has ref 1;
+      """
 
   Scenario: when inserting a roleplayer that can't play the role, an error is thrown
     Then typeql insert; throws exception


### PR DESCRIPTION
## Usage and product changes

No existing insert clauses in tests happened to include relation insertions without explicitly provided role labels. This PR aims to rectify that oversight.